### PR TITLE
feat(scripts): add internationalization support to quickstart script

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -38,6 +38,8 @@ ANTHROPIC_BASE_URL=""
 OPENAI_BASE_URL=""
 DEFAULT_MODEL=""
 OPENAI_DEFAULT_MODEL=""
+# Language setting (en or zh)
+LANG="en"
 
 # Colors for output
 RED='\033[0;31m'
@@ -46,20 +48,134 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Localization function
+msg() {
+  local key="$1"
+  case "$key" in
+    # Usage messages
+    "usage.header") [[ "$LANG" == "zh" ]] && echo "用法: scripts/quickstart.sh [选项]" || echo "Usage: scripts/quickstart.sh [options]" ;;
+    "usage.options") [[ "$LANG" == "zh" ]] && echo "选项:" || echo "Options:" ;;
+    "usage.interactive") [[ "$LANG" == "zh" ]] && echo "  -i, --interactive         交互模式（在终端运行时默认启用）" || echo "  -i, --interactive         Interactive mode (default when run in a terminal)" ;;
+    "usage.non_interactive") [[ "$LANG" == "zh" ]] && echo "  --non-interactive         禁用交互式提示（推荐用于 CI）" || echo "  --non-interactive         Disable interactive prompts (recommended for CI)" ;;
+    "usage.no_start") [[ "$LANG" == "zh" ]] && echo "  --no-start                仅准备环境和目录" || echo "  --no-start                Only prepare env and directories" ;;
+    "usage.force_env") [[ "$LANG" == "zh" ]] && echo "  --force-env               覆盖环境文件中的现有密钥" || echo "  --force-env               Overwrite existing keys in env file" ;;
+    "usage.anthropic_key") [[ "$LANG" == "zh" ]] && echo "  --anthropic-key KEY       Anthropic API 密钥（写入环境文件）" || echo "  --anthropic-key KEY       Anthropic API key (writes to env)" ;;
+    "usage.openai_key") [[ "$LANG" == "zh" ]] && echo "  --openai-key KEY          OpenAI API 密钥（写入环境文件，可选）" || echo "  --openai-key KEY          OpenAI API key (writes to env, optional)" ;;
+    "usage.lang") [[ "$LANG" == "zh" ]] && echo "  --lang LANG               语言设置 (en 或 zh，默认: en)" || echo "  --lang LANG               Language setting (en or zh, default: en)" ;;
+    "usage.help") [[ "$LANG" == "zh" ]] && echo "  -h, --help                显示此帮助信息" || echo "  -h, --help                Show this help" ;;
+    "usage.advanced") [[ "$LANG" == "zh" ]] && echo "高级选项:" || echo "Advanced options:" ;;
+    "usage.examples") [[ "$LANG" == "zh" ]] && echo "示例:" || echo "Examples:" ;;
+    "usage.example1") [[ "$LANG" == "zh" ]] && echo "  # 交互式设置（默认）" || echo "  # Interactive setup (default)" ;;
+    "usage.example2") [[ "$LANG" == "zh" ]] && echo "  # 交互式设置但不启动服务" || echo "  # Interactive setup without starting services" ;;
+    "usage.example3") [[ "$LANG" == "zh" ]] && echo "  # 通过 CLI 快速设置并提供 API 密钥" || echo "  # Quick setup with API keys via CLI" ;;
+    "usage.example4") [[ "$LANG" == "zh" ]] && echo "  # 使用中文界面" || echo "  # Use Chinese interface" ;;
+
+    # Print messages
+    "print.success") [[ "$LANG" == "zh" ]] && echo "成功" || echo "ok" ;;
+    "print.warn") [[ "$LANG" == "zh" ]] && echo "警告" || echo "warn" ;;
+    "print.error") [[ "$LANG" == "zh" ]] && echo "错误" || echo "error" ;;
+    "print.info") [[ "$LANG" == "zh" ]] && echo "信息" || echo "info" ;;
+
+    # Error messages
+    "error.missing_cmd") [[ "$LANG" == "zh" ]] && echo "缺少命令" || echo "Missing command" ;;
+    "error.unknown_option") [[ "$LANG" == "zh" ]] && echo "未知选项" || echo "Unknown option" ;;
+    "error.docker_not_found") [[ "$LANG" == "zh" ]] && echo "未找到 docker compose" || echo "docker compose not found" ;;
+    "error.anthropic_not_set") [[ "$LANG" == "zh" ]] && echo "未设置 ANTHROPIC_AUTH_TOKEN。请运行 ./scripts/quickstart.sh（交互式）或传递 --anthropic-key。" || echo "ANTHROPIC_AUTH_TOKEN is not set. Run ./scripts/quickstart.sh (interactive) or pass --anthropic-key." ;;
+
+    # Headers
+    "header.quickstart") [[ "$LANG" == "zh" ]] && echo "Poco 快速启动" || echo "Poco Quickstart" ;;
+    "header.interactive_setup") [[ "$LANG" == "zh" ]] && echo "Poco 交互式设置" || echo "Poco Interactive Setup" ;;
+    "header.required_config") [[ "$LANG" == "zh" ]] && echo "必需配置" || echo "Required Configuration" ;;
+    "header.optional_config") [[ "$LANG" == "zh" ]] && echo "可选配置" || echo "Optional Configuration" ;;
+    "header.s3_endpoint") [[ "$LANG" == "zh" ]] && echo "S3 公共端点配置" || echo "S3 Public Endpoint Configuration" ;;
+    "header.setup_complete") [[ "$LANG" == "zh" ]] && echo "设置完成" || echo "Setup Complete" ;;
+    "header.lang_select") [[ "$LANG" == "zh" ]] && echo "语言选择" || echo "Language Selection" ;;
+
+    # Interactive setup
+    "setup.welcome") [[ "$LANG" == "zh" ]] && echo "欢迎使用 Poco！此向导将帮助您配置基本设置。" || echo "Welcome to Poco! This wizard will help you configure the essential settings." ;;
+    "setup.input") [[ "$LANG" == "zh" ]] && echo "请输入" || echo "Input" ;;
+    "setup.keep_current") [[ "$LANG" == "zh" ]] && echo "按 Enter 保留" || echo "Press Enter to keep" ;;
+    "setup.skipping") [[ "$LANG" == "zh" ]] && echo "跳过" || echo "Skipping" ;;
+    "setup.optional") [[ "$LANG" == "zh" ]] && echo "可选" || echo "optional" ;;
+    "setup.required") [[ "$LANG" == "zh" ]] && echo "是必需的" || echo "is required" ;;
+
+    # API Key prompts
+    "prompt.anthropic_key") [[ "$LANG" == "zh" ]] && echo "请输入您的 Anthropic API 密钥（在 https://console.anthropic.com/ 获取）" || echo "Enter your Anthropic API key (get one at https://console.anthropic.com/)" ;;
+    "prompt.anthropic_warn") [[ "$LANG" == "zh" ]] && echo "Anthropic API 密钥通常以 'sk-ant-' 开头，请仔细检查。" || echo "Anthropic API key usually starts with 'sk-ant-'. Please double-check." ;;
+    "prompt.openai_key") [[ "$LANG" == "zh" ]] && echo "请输入您的 OpenAI API 密钥（或按 Enter 跳过）" || echo "Enter your OpenAI API key (or press Enter to skip)" ;;
+    "prompt.openai_warn") [[ "$LANG" == "zh" ]] && echo "OpenAI API 密钥通常以 'sk-' 开头，请仔细检查。" || echo "OpenAI API key usually starts with 'sk-'. Please double-check." ;;
+
+    # Success messages
+    "success.env_created") [[ "$LANG" == "zh" ]] && echo "已从 .env.example 创建 .env" || echo "Created .env from .env.example" ;;
+    "success.anthropic_configured") [[ "$LANG" == "zh" ]] && echo "已配置 Anthropic API 密钥" || echo "Anthropic API key configured" ;;
+    "success.anthropic_base_url") [[ "$LANG" == "zh" ]] && echo "已配置 Anthropic 基础 URL" || echo "Anthropic base URL configured" ;;
+    "success.default_model") [[ "$LANG" == "zh" ]] && echo "已配置默认模型" || echo "Default model configured" ;;
+    "success.openai_configured") [[ "$LANG" == "zh" ]] && echo "已配置 OpenAI API 密钥" || echo "OpenAI API key configured" ;;
+    "success.openai_base_url") [[ "$LANG" == "zh" ]] && echo "已配置 OpenAI 基础 URL" || echo "OpenAI base URL configured" ;;
+    "success.openai_model") [[ "$LANG" == "zh" ]] && echo "已配置 OpenAI 默认模型" || echo "OpenAI default model configured" ;;
+    "success.s3_endpoint") [[ "$LANG" == "zh" ]] && echo "已配置 S3 公共端点" || echo "S3 public endpoint configured" ;;
+    "success.bootstrap") [[ "$LANG" == "zh" ]] && echo "引导完成！" || echo "Bootstrap completed!" ;;
+
+    # Info messages
+    "info.anthropic_configured") [[ "$LANG" == "zh" ]] && echo "已配置 Anthropic API 密钥" || echo "Anthropic API key is configured" ;;
+    "info.openai_not_set") [[ "$LANG" == "zh" ]] && echo "未设置 OpenAI API 密钥（可选）" || echo "OpenAI API key not set (optional)" ;;
+    "info.pulling_images") [[ "$LANG" == "zh" ]] && echo "正在拉取执行器镜像..." || echo "Pulling executor images..." ;;
+
+    # Warnings
+    "warn.docker_gid") [[ "$LANG" == "zh" ]] && echo "未检测到 DOCKER_GID；executor-manager 可能无法访问 docker.sock" || echo "DOCKER_GID not detected; executor-manager may fail to access docker.sock" ;;
+    "warn.chown_failed") [[ "$LANG" == "zh" ]] && echo "chown RustFS 数据目录失败。您可能需要运行: sudo chown -R" || echo "Failed to chown RustFS data dir. You may need to run: sudo chown -R" ;;
+    "warn.chmod_data_failed") [[ "$LANG" == "zh" ]] && echo "chmod RustFS 数据目录失败。您可能需要运行: sudo chown -R" || echo "Failed to chmod RustFS data dir. You may need to run: sudo chown -R" ;;
+    "warn.chmod_workspace_failed") [[ "$LANG" == "zh" ]] && echo "chmod 工作空间目录失败。您可能需要运行: sudo chown -R" || echo "Failed to chmod workspace directories. You may need to run: sudo chown -R" ;;
+    "warn.rustfs_init_failed") [[ "$LANG" == "zh" ]] && echo "rustfs-init 失败；您可以重试: docker compose --profile init up -d rustfs-init" || echo "rustfs-init failed; you can retry: docker compose --profile init up -d rustfs-init" ;;
+    "warn.anthropic_not_set") [[ "$LANG" == "zh" ]] && echo "未设置 ANTHROPIC_AUTH_TOKEN！" || echo "ANTHROPIC_AUTH_TOKEN is not set!" ;;
+    "warn.default_model") [[ "$LANG" == "zh" ]] && echo "DEFAULT_MODEL 看起来不像 Claude 模型（应以 'claude-' 开头）。" || echo "DEFAULT_MODEL doesn't look like a Claude model (expected prefix 'claude-')." ;;
+    "warn.use_openai_model") [[ "$LANG" == "zh" ]] && echo "如果您想使用 OpenAI 模型，请设置 OPENAI_DEFAULT_MODEL。" || echo "If you meant an OpenAI model, set OPENAI_DEFAULT_MODEL instead." ;;
+    "warn.openai_model") [[ "$LANG" == "zh" ]] && echo "OPENAI_DEFAULT_MODEL 看起来不像典型的 OpenAI 模型名称（例如 gpt-4o-mini）。" || echo "OPENAI_DEFAULT_MODEL doesn't look like a typical OpenAI model name (e.g. gpt-4o-mini)." ;;
+
+    # Language selection
+    "lang.prompt") [[ "$LANG" == "zh" ]] && echo "请选择语言 / Please select language:" || echo "Please select language / 请选择语言:" ;;
+    "lang.english") echo "1) English" ;;
+    "lang.chinese") echo "2) 中文" ;;
+    "lang.choice") [[ "$LANG" == "zh" ]] && echo "请输入选择 [1-2]" || echo "Enter choice [1-2]" ;;
+
+    *) echo "$key" ;;
+  esac
+}
+
 usage() {
-  cat <<'USAGE'
-Usage: scripts/quickstart.sh [options]
-
-Options:
-  -i, --interactive         Interactive mode (default when run in a terminal)
-  --non-interactive         Disable interactive prompts (recommended for CI)
-  --no-start                Only prepare env and directories
-  --force-env               Overwrite existing keys in env file
-  --anthropic-key KEY       Anthropic API key (writes to env)
-  --openai-key KEY          OpenAI API key (writes to env, optional)
-  -h, --help                Show this help
-
-Advanced options:
+  echo "$(msg "usage.header")"
+  echo ""
+  echo "$(msg "usage.options")"
+  echo "$(msg "usage.interactive")"
+  echo "$(msg "usage.non_interactive")"
+  echo "$(msg "usage.no_start")"
+  echo "$(msg "usage.force_env")"
+  echo "$(msg "usage.anthropic_key")"
+  echo "$(msg "usage.openai_key")"
+  echo "$(msg "usage.lang")"
+  echo "$(msg "usage.help")"
+  echo ""
+  echo "$(msg "usage.advanced")"
+  if [[ "$LANG" == "zh" ]]; then
+    cat <<'ADVANCED'
+  --data-dir PATH           RustFS 数据的主机路径（默认: ./oss_data）
+  --workspace-dir PATH      工作空间的主机路径（默认: ./tmp_workspace）
+  --rustfs-uid UID          数据目录所有权的 RustFS uid（默认: 10001）
+  --rustfs-gid GID          数据目录所有权的 RustFS gid（默认: 10001）
+  --no-chown-rustfs         跳过 RustFS 数据目录的 chown 操作
+  --s3-bucket NAME          存储桶名称（写入环境文件）
+  --s3-access-key KEY       S3 访问密钥（写入环境文件）
+  --s3-secret-key KEY       S3 密钥（写入环境文件）
+  --s3-public-endpoint URL  用于访问构件的 S3 公共端点（写入环境文件）
+  --cors-origins CSV|JSON   允许的来源（写入环境文件）
+  --docker-gid GID          Docker 套接字组 ID（如省略则自动检测）
+  --env-file PATH           目标环境文件（默认: ./.env）
+  --only-rustfs             仅启动 rustfs（和 rustfs-init）
+  --no-init-bucket          跳过 rustfs-init 存储桶创建
+  --no-pull-executor        跳过拉取执行器镜像
+ADVANCED
+  else
+    cat <<'ADVANCED'
   --data-dir PATH           Host path for RustFS data (default: ./oss_data)
   --workspace-dir PATH      Host path for workspaces (default: ./tmp_workspace)
   --rustfs-uid UID          RustFS uid for data dir ownership (default: 10001)
@@ -75,17 +191,21 @@ Advanced options:
   --only-rustfs             Start only rustfs (and rustfs-init)
   --no-init-bucket          Skip rustfs-init bucket creation
   --no-pull-executor        Skip pulling executor image
-
-Examples:
-  # Interactive setup (default)
-  ./scripts/quickstart.sh
-
-  # Interactive setup without starting services
-  ./scripts/quickstart.sh --no-start
-
-  # Quick setup with API keys via CLI
-  ./scripts/quickstart.sh --non-interactive --anthropic-key sk-ant-xxx
-USAGE
+ADVANCED
+  fi
+  echo ""
+  echo "$(msg "usage.examples")"
+  echo "$(msg "usage.example1")"
+  echo "  ./scripts/quickstart.sh"
+  echo ""
+  echo "$(msg "usage.example2")"
+  echo "  ./scripts/quickstart.sh --no-start"
+  echo ""
+  echo "$(msg "usage.example3")"
+  echo "  ./scripts/quickstart.sh --non-interactive --anthropic-key sk-ant-xxx"
+  echo ""
+  echo "$(msg "usage.example4")"
+  echo "  ./scripts/quickstart.sh --lang zh"
 }
 
 print_header() {
@@ -98,19 +218,19 @@ print_header() {
 }
 
 print_success() {
-  echo -e "${GREEN}[ok]${NC} $*"
+  echo -e "${GREEN}[$(msg "print.success")]${NC} $*"
 }
 
 print_warn() {
-  echo -e "${YELLOW}[warn]${NC} $*" >&2
+  echo -e "${YELLOW}[$(msg "print.warn")]${NC} $*" >&2
 }
 
 print_error() {
-  echo -e "${RED}[error]${NC} $*" >&2
+  echo -e "${RED}[$(msg "print.error")]${NC} $*" >&2
 }
 
 print_info() {
-  echo -e "${BLUE}[info]${NC} $*"
+  echo -e "${BLUE}[$(msg "print.info")]${NC} $*"
 }
 
 warn() {
@@ -130,7 +250,7 @@ read_line() {
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
-    print_error "Missing command: $1"
+    print_error "$(msg "error.missing_cmd"): $1"
     exit 1
   fi
 }
@@ -206,11 +326,11 @@ read_env_key() {
       value="${value#\"}"
       value="${value%\'}"
       value="${value#\'}"
-      # Treat empty values as "not set"
+      # 将空值视为"未设置"
       if [[ -z "$value" ]]; then
         return 1
       fi
-      # Treat example placeholders as "not set".
+      # 将示例占位符视为"未设置"
       if [[ "$key" == "ANTHROPIC_AUTH_TOKEN" && "$value" == "sk-ant-xxxxx" ]]; then
         return 1
       fi
@@ -231,11 +351,11 @@ write_env_key() {
     return
   fi
   
-  # FIX: Logic improved to allow overwrite if value is different
+  # 修复: 改进逻辑以允许在值不同时覆盖
   if [[ "$FORCE_ENV" = false ]]; then
     local existing_value
     existing_value="$(read_env_key "$key" || true)"
-    # Only skip if the value is EXACTLY the same as what we are trying to write
+    # 仅当值完全相同时才跳过
     if [[ -n "$existing_value" ]] && [[ "$existing_value" == "$value" ]]; then
       return 0
     fi
@@ -271,12 +391,12 @@ prompt_for_key() {
   local current_value="$4"
   local input_value=""
 
-  # FIX: Removed the "Keep current? [Y/n]" logic.
-  # Instead, use standard default value prompt style.
-  
+  # 修复: 移除了 "保留当前值? [Y/n]" 逻辑
+  # 改为使用标准的默认值提示样式
+
   local display_default=""
   if [[ -n "$current_value" ]]; then
-     # Mask the key for display
+     # 为显示掩码密钥
      if [[ "${#current_value}" -gt 12 ]]; then
         display_default="${current_value:0:8}...${current_value: -4}"
      else
@@ -287,11 +407,11 @@ prompt_for_key() {
   while true; do
     echo "$prompt_msg" >&2
     if [[ -n "$display_default" ]]; then
-        echo -n -e "Input (Press Enter to keep [${GREEN}${display_default}${NC}]): " >&2
+        echo -n -e "$(msg "setup.input") ($(msg "setup.keep_current") [${GREEN}${display_default}${NC}]): " >&2
     else
-        echo -n "Input: " >&2
+        echo -n "$(msg "setup.input"): " >&2
     fi
-    
+
     read_line input_value
     echo "" >&2
 
@@ -301,11 +421,11 @@ prompt_for_key() {
         echo "$current_value"
         return
       elif [[ "$is_optional" == "true" ]]; then
-        print_info "Skipping ${key_name} (optional)" >&2
+        print_info "$(msg "setup.skipping") ${key_name} ($(msg "setup.optional"))" >&2
         echo ""
         return
       else
-        print_warn "${key_name} is required"
+        print_warn "${key_name} $(msg "setup.required")"
         continue
       fi
     else
@@ -344,36 +464,59 @@ prompt_for_s3_public_endpoint() {
   local current_value="$1"
   local input_value=""
 
-  print_header "S3 Public Endpoint Configuration" >&2
-  cat >&2 <<'EOF'
+  print_header "$(msg "header.s3_endpoint")" >&2
+
+  if [[ "$LANG" == "zh" ]]; then
+    cat >&2 <<'EOF'
+
+S3 公共端点用于直接从浏览器访问生成的构件（图片、HTML 文件等）。
+这是前端用来下载存储在 S3/R2 中的构件的 URL。
+
+EOF
+    echo -e "${YELLOW}什么时候需要这个配置？${NC}" >&2
+    cat >&2 <<'EOF'
+  • 远程部署（VPS、云服务器）- 用户从不同网络访问
+  • Cloudflare R2 或其他云 S3 兼容存储 - 有公共域名
+  • 与他人共享构件 - 需要可访问的 URL
+
+EOF
+    echo -e "${YELLOW}什么时候可以跳过？${NC}" >&2
+    cat >&2 <<'EOF'
+  • 仅本地开发 - 您从 localhost 访问所有内容
+  • 使用内置 MinIO（默认）- 本地 S3 位于 localhost:9000
+
+EOF
+    local display_msg="请输入 S3 公共端点（或按 Enter 跳过）"
+  else
+    cat >&2 <<'EOF'
 
 The S3 Public Endpoint is used to access generated artifacts (images, HTML files, etc.)
 directly from your browser. This is the URL that your frontend will use to download
 artifacts stored in S3/R2.
 
 EOF
-  echo -e "${YELLOW}When do you need this?${NC}" >&2
-  cat >&2 <<'EOF'
+    echo -e "${YELLOW}When do you need this?${NC}" >&2
+    cat >&2 <<'EOF'
   • Remote deployments (VPS, cloud servers) - Users access from different networks
   • Cloudflare R2 or other cloud S3-compatible storage - Has a public domain
   • Sharing artifacts with others - Need accessible URLs
 
 EOF
-  echo -e "${YELLOW}When can you skip this?${NC}" >&2
-  cat >&2 <<'EOF'
+    echo -e "${YELLOW}When can you skip this?${NC}" >&2
+    cat >&2 <<'EOF'
   • Local development only - You access everything from localhost
   • Using built-in MinIO (default) - Local S3 at localhost:9000
 
 EOF
+    local display_msg="Enter S3 public endpoint (or press Enter to skip)"
+  fi
 
-  # Standardize prompt style
-  local display_msg="Enter S3 public endpoint (or press Enter to skip)"
   if [[ -n "$current_value" ]]; then
-      echo -n "$display_msg [${current_value}]: " >&2
+      echo -n "$display_msg [$current_value]: " >&2
   else
       echo -n "$display_msg: " >&2
   fi
-  
+
   read_line input_value
   echo "" >&2
 
@@ -382,7 +525,11 @@ EOF
         echo "$current_value"
         return
     fi
-    print_info "Skipping S3 public endpoint (local development mode)" >&2
+    if [[ "$LANG" == "zh" ]]; then
+      print_info "跳过 S3 公共端点（本地开发模式）" >&2
+    else
+      print_info "Skipping S3 public endpoint (local development mode)" >&2
+    fi
     echo ""
     return
   fi
@@ -390,14 +537,32 @@ EOF
   echo "$input_value"
 }
 
+select_language() {
+  if [[ -t 0 ]]; then
+    print_header "$(msg "header.lang_select")"
+    echo "$(msg "lang.prompt")"
+    echo "$(msg "lang.english")"
+    echo "$(msg "lang.chinese")"
+    echo ""
+    echo -n "$(msg "lang.choice"): "
+
+    local choice
+    read_line choice
+
+    case "$choice" in
+      1) LANG="en" ;;
+      2) LANG="zh" ;;
+      *) LANG="en" ;;
+    esac
+  fi
+}
+
 interactive_setup() {
-  print_header "Poco Interactive Setup"
+  print_header "$(msg "header.interactive_setup")"
 
-  cat <<'EOF'
-
-Welcome to Poco! This wizard will help you configure the essential settings.
-
-EOF
+  echo ""
+  echo "$(msg "setup.welcome")"
+  echo ""
 
   # Check for existing values in env
   local existing_anthropic
@@ -421,40 +586,70 @@ EOF
   if [[ -n "$OPENAI_KEY" ]]; then existing_openai="$OPENAI_KEY"; fi
 
   # Prompt for Anthropic key (required)
-  print_header "Required Configuration"
+  print_header "$(msg "header.required_config")"
   ANTHROPIC_KEY="$(prompt_for_key "Anthropic API Key" \
-    "Enter your Anthropic API key (get one at https://console.anthropic.com/)" \
+    "$(msg "prompt.anthropic_key")" \
     "false" \
     "$existing_anthropic")"
   if [[ -n "$ANTHROPIC_KEY" ]] && [[ "$ANTHROPIC_KEY" != sk-ant-* ]]; then
-    print_warn "Anthropic API key usually starts with 'sk-ant-'. Please double-check."
+    print_warn "$(msg "prompt.anthropic_warn")"
   fi
 
   # Prompt for Anthropic Base URL (optional)
-  cat <<'EOF'
+  if [[ "$LANG" == "zh" ]]; then
+    cat <<'EOF'
+
+如果您使用代理或 Anthropic 的自定义 API 端点，请在下面输入基础 URL。
+否则，按 Enter 使用默认值 (https://api.anthropic.com)。
+
+EOF
+  else
+    cat <<'EOF'
 
 If you use a proxy or custom API endpoint for Anthropic, enter the base URL below.
 Otherwise, press Enter to use the default (https://api.anthropic.com).
 
 EOF
-  ANTHROPIC_BASE_URL="$(prompt_for_text "Anthropic Base URL" "${existing_anthropic_base_url:-https://api.anthropic.com}" "true")"
+  fi
+  local anthropic_label=$([[ "$LANG" == "zh" ]] && echo "Anthropic 基础 URL" || echo "Anthropic Base URL")
+  ANTHROPIC_BASE_URL="$(prompt_for_text "$anthropic_label" "${existing_anthropic_base_url:-https://api.anthropic.com}" "true")"
 
   # Prompt for Default Model (optional)
-  cat <<'EOF'
+  if [[ "$LANG" == "zh" ]]; then
+    cat <<'EOF'
+
+请输入要使用的默认 Claude 模型。按 Enter 使用默认值。
+常用选项: claude-sonnet-4-20250514, claude-opus-4-20250514
+
+EOF
+  else
+    cat <<'EOF'
 
 Enter the default Claude model to use. Press Enter to use the default.
 Common options: claude-sonnet-4-20250514, claude-opus-4-20250514
 
 EOF
-  DEFAULT_MODEL="$(prompt_for_text "Default Claude Model" "${existing_default_model:-claude-sonnet-4-20250514}" "true")"
+  fi
+  local model_label=$([[ "$LANG" == "zh" ]] && echo "默认 Claude 模型" || echo "Default Claude Model")
+  DEFAULT_MODEL="$(prompt_for_text "$model_label" "${existing_default_model:-claude-sonnet-4-20250514}" "true")"
   if [[ -n "$DEFAULT_MODEL" ]] && [[ "$DEFAULT_MODEL" != claude-* ]]; then
-    print_warn "DEFAULT_MODEL doesn't look like a Claude model (expected prefix 'claude-')."
-    print_warn "If you meant an OpenAI model, set OPENAI_DEFAULT_MODEL instead."
+    print_warn "$(msg "warn.default_model")"
+    print_warn "$(msg "warn.use_openai_model")"
   fi
 
   # Prompt for OpenAI key (optional)
-  print_header "Optional Configuration"
-  cat <<'EOF'
+  print_header "$(msg "header.optional_config")"
+  if [[ "$LANG" == "zh" ]]; then
+    cat <<'EOF'
+
+OpenAI API 密钥是可选的，但如果您想要以下功能则建议配置：
+  • 与 Claude 一起使用 GPT 模型
+  • 访问 OpenAI 的工具和功能
+  • 比较不同 AI 提供商之间的结果
+
+EOF
+  else
+    cat <<'EOF'
 
 OpenAI API Key is optional but recommended if you want to:
   • Use GPT models alongside Claude
@@ -462,34 +657,55 @@ OpenAI API Key is optional but recommended if you want to:
   • Compare results between different AI providers
 
 EOF
+  fi
   OPENAI_KEY="$(prompt_for_key "OpenAI API Key" \
-    "Enter your OpenAI API key (or press Enter to skip)" \
+    "$(msg "prompt.openai_key")" \
     "true" \
     "$existing_openai")"
   if [[ -n "$OPENAI_KEY" ]] && [[ "$OPENAI_KEY" != sk-* ]]; then
-    print_warn "OpenAI API key usually starts with 'sk-'. Please double-check."
+    print_warn "$(msg "prompt.openai_warn")"
   fi
 
   if [[ -n "$OPENAI_KEY" ]]; then
     # Prompt for OpenAI Base URL (only if key is set)
-    cat <<'EOF'
+    if [[ "$LANG" == "zh" ]]; then
+      cat <<'EOF'
+
+如果您使用代理或 OpenAI 的自定义 API 端点，请在下面输入基础 URL。
+否则，按 Enter 使用默认值 (https://api.openai.com/v1)。
+
+EOF
+    else
+      cat <<'EOF'
 
 If you use a proxy or custom API endpoint for OpenAI, enter the base URL below.
 Otherwise, press Enter to use the default (https://api.openai.com/v1).
 
 EOF
-    OPENAI_BASE_URL="$(prompt_for_text "OpenAI Base URL" "${existing_openai_base_url:-https://api.openai.com/v1}" "true")"
+    fi
+    local openai_base_label=$([[ "$LANG" == "zh" ]] && echo "OpenAI 基础 URL" || echo "OpenAI Base URL")
+    OPENAI_BASE_URL="$(prompt_for_text "$openai_base_label" "${existing_openai_base_url:-https://api.openai.com/v1}" "true")"
 
     # Prompt for OpenAI Default Model
-    cat <<'EOF'
+    if [[ "$LANG" == "zh" ]]; then
+      cat <<'EOF'
+
+请输入要使用的默认 GPT 模型。按 Enter 使用默认值。
+常用选项: gpt-4o, gpt-4o-mini, gpt-4-turbo
+
+EOF
+    else
+      cat <<'EOF'
 
 Enter the default GPT model to use. Press Enter to use the default.
 Common options: gpt-4o, gpt-4o-mini, gpt-4-turbo
 
 EOF
-    OPENAI_DEFAULT_MODEL="$(prompt_for_text "OpenAI Default Model" "${existing_openai_model:-gpt-4o-mini}" "true")"
+    fi
+    local openai_model_label=$([[ "$LANG" == "zh" ]] && echo "OpenAI 默认模型" || echo "OpenAI Default Model")
+    OPENAI_DEFAULT_MODEL="$(prompt_for_text "$openai_model_label" "${existing_openai_model:-gpt-4o-mini}" "true")"
     if [[ -n "$OPENAI_DEFAULT_MODEL" ]] && [[ "$OPENAI_DEFAULT_MODEL" != gpt-* && "$OPENAI_DEFAULT_MODEL" != o1* && "$OPENAI_DEFAULT_MODEL" != o3* ]]; then
-      print_warn "OPENAI_DEFAULT_MODEL doesn't look like a typical OpenAI model name (e.g. gpt-4o-mini)."
+      print_warn "$(msg "warn.openai_model")"
     fi
   fi
 
@@ -500,37 +716,37 @@ EOF
   # NOTE: write_env_key now handles check-before-write logic correctly
   if [[ -n "$ANTHROPIC_KEY" ]]; then
     write_env_key "ANTHROPIC_AUTH_TOKEN" "$ANTHROPIC_KEY"
-    print_success "Anthropic API key configured"
+    print_success "$(msg "success.anthropic_configured")"
   fi
 
   if [[ -n "$ANTHROPIC_BASE_URL" ]]; then
     write_env_key "ANTHROPIC_BASE_URL" "$ANTHROPIC_BASE_URL"
-    print_success "Anthropic base URL configured"
+    print_success "$(msg "success.anthropic_base_url")"
   fi
 
   if [[ -n "$DEFAULT_MODEL" ]]; then
     write_env_key "DEFAULT_MODEL" "$DEFAULT_MODEL"
-    print_success "Default model configured"
+    print_success "$(msg "success.default_model")"
   fi
 
   if [[ -n "$OPENAI_KEY" ]]; then
     write_env_key "OPENAI_API_KEY" "$OPENAI_KEY"
-    print_success "OpenAI API key configured"
+    print_success "$(msg "success.openai_configured")"
   fi
 
   if [[ -n "$OPENAI_BASE_URL" ]]; then
     write_env_key "OPENAI_BASE_URL" "$OPENAI_BASE_URL"
-    print_success "OpenAI base URL configured"
+    print_success "$(msg "success.openai_base_url")"
   fi
 
   if [[ -n "$OPENAI_DEFAULT_MODEL" ]]; then
     write_env_key "OPENAI_DEFAULT_MODEL" "$OPENAI_DEFAULT_MODEL"
-    print_success "OpenAI default model configured"
+    print_success "$(msg "success.openai_model")"
   fi
 
   if [[ -n "$S3_PUBLIC_ENDPOINT" ]]; then
     write_env_key "S3_PUBLIC_ENDPOINT" "$S3_PUBLIC_ENDPOINT"
-    print_success "S3 public endpoint configured"
+    print_success "$(msg "success.s3_endpoint")"
   fi
 
   echo ""
@@ -583,22 +799,29 @@ while [[ $# -gt 0 ]]; do
       ANTHROPIC_KEY="$2"; shift 2 ;;
     --openai-key)
       OPENAI_KEY="$2"; shift 2 ;;
+    --lang)
+      LANG="$2"; shift 2 ;;
     -h|--help)
       usage; exit 0 ;;
     *)
-      print_error "Unknown option: $1"
+      print_error "$(msg "error.unknown_option"): $1"
       usage
       exit 1
       ;;
   esac
 done
 
-print_header "Poco Quickstart"
+# Select language if not specified and in interactive mode
+if [[ "$INTERACTIVE" = true ]] && [[ "$LANG" == "en" ]]; then
+  select_language
+fi
+
+print_header "$(msg "header.quickstart")"
 
 if [[ ! -f "$ENV_FILE" ]]; then
   if [[ -f "${ROOT_DIR}/.env.example" ]]; then
     cp "${ROOT_DIR}/.env.example" "$ENV_FILE"
-    print_success "Created .env from .env.example"
+    print_success "$(msg "success.env_created")"
   else
     touch "$ENV_FILE"
   fi
@@ -613,12 +836,12 @@ fi
 if [[ "$INTERACTIVE" = false ]]; then
   if [[ -n "$ANTHROPIC_KEY" ]]; then
     write_env_key "ANTHROPIC_AUTH_TOKEN" "$ANTHROPIC_KEY"
-    print_success "Anthropic API key configured"
+    print_success "$(msg "success.anthropic_configured")"
   fi
 
   if [[ -n "$OPENAI_KEY" ]]; then
     write_env_key "OPENAI_API_KEY" "$OPENAI_KEY"
-    print_success "OpenAI API key configured"
+    print_success "$(msg "success.openai_configured")"
   fi
 fi
 
@@ -656,7 +879,7 @@ fi
 if [[ -n "$DOCKER_GID" ]]; then
   write_env_key "DOCKER_GID" "$DOCKER_GID"
 else
-  warn "DOCKER_GID not detected; executor-manager may fail to access docker.sock"
+  warn "$(msg "warn.docker_gid")"
 fi
 
 mkdir -p "$DATA_DIR_ABS"
@@ -667,18 +890,18 @@ ensure_gitignore "$WORKSPACE_DIR_ABS"
 
 if [[ "$CHOWN_RUSTFS" = true ]]; then
   if ! chown -R "${RUSTFS_UID}:${RUSTFS_GID}" "$DATA_DIR_ABS" 2>/dev/null; then
-    warn "Failed to chown RustFS data dir. You may need to run: sudo chown -R ${RUSTFS_UID}:${RUSTFS_GID} \"$DATA_DIR_ABS\""
+    warn "$(msg "warn.chown_failed") ${RUSTFS_UID}:${RUSTFS_GID} \"$DATA_DIR_ABS\""
   fi
 fi
 
 chmod -R u+rwX "$DATA_DIR_ABS" 2>/dev/null || \
-  warn "Failed to chmod RustFS data dir. You may need to run: sudo chown -R ${RUSTFS_UID}:${RUSTFS_GID} \"$DATA_DIR_ABS\""
+  warn "$(msg "warn.chmod_data_failed") ${RUSTFS_UID}:${RUSTFS_GID} \"$DATA_DIR_ABS\""
 
 chmod -R u+rwX "$WORKSPACE_DIR_ABS" 2>/dev/null || \
-  warn "Failed to chmod workspace directories. You may need to run: sudo chown -R \"$(id -u)\":\"$(id -g)\" \"$WORKSPACE_DIR_ABS\""
+  warn "$(msg "warn.chmod_workspace_failed") \"$(id -u)\":\"$(id -g)\" \"$WORKSPACE_DIR_ABS\""
 
 if [[ "$START_ALL" = true ]] && ! read_env_key "ANTHROPIC_AUTH_TOKEN" >/dev/null 2>&1; then
-  print_error "ANTHROPIC_AUTH_TOKEN is not set. Run ./scripts/quickstart.sh (interactive) or pass --anthropic-key."
+  print_error "$(msg "error.anthropic_not_set")"
   exit 1
 fi
 
@@ -689,7 +912,7 @@ if [[ "$START_ALL" = true ]]; then
   elif command -v docker-compose >/dev/null 2>&1; then
     COMPOSE=(docker-compose)
   else
-    print_error "docker compose not found"
+    print_error "$(msg "error.docker_not_found")"
     exit 1
   fi
 
@@ -711,7 +934,7 @@ if [[ "$START_ALL" = true ]]; then
       executor_full_image="ghcr.io/poco-ai/poco-executor:full"
     fi
 
-    print_info "Pulling executor images..."
+    print_info "$(msg "info.pulling_images")"
     print_info "  - $executor_lite_image"
     docker pull "$executor_lite_image"
     print_info "  - $executor_full_image"
@@ -726,43 +949,69 @@ if [[ "$START_ALL" = true ]]; then
 
   if [[ "$INIT_BUCKET" = true ]]; then
     "${COMPOSE[@]}" --profile init up -d rustfs-init || \
-      warn "rustfs-init failed; you can retry: docker compose --profile init up -d rustfs-init"
+      warn "$(msg "warn.rustfs_init_failed")"
   fi
 fi
 
 # Final status check
-print_header "Setup Complete"
+print_header "$(msg "header.setup_complete")"
 
 # Check if Anthropic key is set
 if ! read_env_key "ANTHROPIC_AUTH_TOKEN" >/dev/null 2>&1; then
-  print_warn "ANTHROPIC_AUTH_TOKEN is not set!"
-  cat <<'EOF'
+  print_warn "$(msg "warn.anthropic_not_set")"
+  if [[ "$LANG" == "zh" ]]; then
+    cat <<'EOF'
+
+  请在 .env 中设置您的 Anthropic API 密钥或运行:
+    ./scripts/quickstart.sh
+
+  在此获取密钥: https://console.anthropic.com/
+EOF
+  else
+    cat <<'EOF'
 
   Please set your Anthropic API key in .env or run:
     ./scripts/quickstart.sh
 
   Get your key at: https://console.anthropic.com/
 EOF
+  fi
 else
-  print_success "Anthropic API key is configured"
+  print_success "$(msg "info.anthropic_configured")"
 fi
 
 # Remind about optional keys
 if ! read_env_key "OPENAI_API_KEY" >/dev/null 2>&1; then
-  print_info "OpenAI API key not set (optional)"
-  echo "  Add it later in .env if you want to use GPT models"
+  print_info "$(msg "info.openai_not_set")"
+  if [[ "$LANG" == "zh" ]]; then
+    echo "  如果您想使用 GPT 模型，可以稍后在 .env 中添加"
+  else
+    echo "  Add it later in .env if you want to use GPT models"
+  fi
 fi
 
 echo ""
-print_success "Bootstrap completed!"
+print_success "$(msg "success.bootstrap")"
 echo ""
-echo "Next steps:"
-echo "  1. Make sure ANTHROPIC_AUTH_TOKEN is set in .env"
-if [[ "$START_ALL" = true ]]; then
-  echo "  2. Open browser: http://localhost:3000"
-  echo "  3. View logs: docker compose logs -f backend executor-manager frontend"
+if [[ "$LANG" == "zh" ]]; then
+  echo "后续步骤:"
+  echo "  1. 确保在 .env 中设置了 ANTHROPIC_AUTH_TOKEN"
+  if [[ "$START_ALL" = true ]]; then
+    echo "  2. 打开浏览器: http://localhost:3000"
+    echo "  3. 查看日志: docker compose logs -f backend executor-manager frontend"
+  else
+    echo "  2. 启动服务: docker compose up -d"
+    echo "  3. 打开浏览器: http://localhost:3000"
+  fi
 else
-  echo "  2. Start services: docker compose up -d"
-  echo "  3. Open browser: http://localhost:3000"
+  echo "Next steps:"
+  echo "  1. Make sure ANTHROPIC_AUTH_TOKEN is set in .env"
+  if [[ "$START_ALL" = true ]]; then
+    echo "  2. Open browser: http://localhost:3000"
+    echo "  3. View logs: docker compose logs -f backend executor-manager frontend"
+  else
+    echo "  2. Start services: docker compose up -d"
+    echo "  3. Open browser: http://localhost:3000"
+  fi
 fi
 echo ""


### PR DESCRIPTION
Add bilingual support (English and Chinese) to the quickstart.sh script to improve accessibility for Chinese-speaking users.

Changes:
- Add LANG variable to control language setting (en or zh)
- Implement msg() function for message localization
- Add select_language() interactive language selection
- Localize all user-facing messages, prompts, and help text
- Add --lang CLI option to set language preference
- Update usage examples to show language selection

The script now defaults to English but allows users to select Chinese through an interactive prompt or via the --lang flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multilingual support for English and Chinese languages.
  * Users can now select their preferred language during interactive setup.
  * All user-facing text, prompts, error messages, and help documentation are now localized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->