### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/backend/app/services/model_config_service.py
+++ b/backend/app/services/model_config_service.py
@@ -77,6 +77,19 @@ PROVIDER_SPECS: tuple[ProviderSpec, ...] = (
             ("deepseek-reasoner", "DeepSeek Reasoner"),
         ),
     ),
+    ProviderSpec(
+        provider_id="novita",
+        display_name="Novita AI",
+        api_key_env_key="NOVITA_API_KEY",
+        base_url_env_key="NOVITA_BASE_URL",
+        default_base_url="https://api.novita.ai/openai",
+        known_models=(
+            ("moonshotai/kimi-k2.5", "Kimi K2.5"),
+            ("deepseek/deepseek-v3.2", "DeepSeek V3.2"),
+            ("zai-org/glm-5", "GLM-5"),
+            ("qwen/qwen3-embedding-0.6b", "Qwen3 Embedding 0.6B"),
+        ),
+    ),
 )
 
 PROVIDER_SPEC_MAP = {spec.provider_id: spec for spec in PROVIDER_SPECS}
@@ -101,6 +114,13 @@ def infer_provider_id(model_id: str) -> str | None:
         return "minimax"
     if lowered.startswith("deepseek-"):
         return "deepseek"
+    if (
+        lowered.startswith("moonshotai/")
+        or lowered.startswith("deepseek/")
+        or lowered.startswith("zai-org/")
+        or lowered.startswith("qwen/")
+    ):
+        return "novita"
     return None
 
 

--- a/executor_manager/app/core/settings.py
+++ b/executor_manager/app/core/settings.py
@@ -97,6 +97,8 @@ class Settings(BaseSettings):
     minimax_base_url: str | None = Field(default=None, alias="MINIMAX_BASE_URL")
     deepseek_api_key: str | None = Field(default=None, alias="DEEPSEEK_API_KEY")
     deepseek_base_url: str | None = Field(default=None, alias="DEEPSEEK_BASE_URL")
+    novita_api_key: str | None = Field(default=None, alias="NOVITA_API_KEY")
+    novita_base_url: str | None = Field(default=None, alias="NOVITA_BASE_URL")
     default_model: str = Field(
         default="claude-sonnet-4-20250514", alias="DEFAULT_MODEL"
     )

--- a/executor_manager/app/services/config_resolver.py
+++ b/executor_manager/app/services/config_resolver.py
@@ -62,6 +62,15 @@ _PROVIDER_RUNTIME_SPECS: dict[str, ProviderRuntimeSpec] = {
         "runtime_api_key_env_key": "ANTHROPIC_API_KEY",
         "runtime_base_url_env_key": "ANTHROPIC_BASE_URL",
     },
+    "novita": {
+        "source_api_key_env_keys": ("NOVITA_API_KEY",),
+        "source_base_url_env_keys": ("NOVITA_BASE_URL",),
+        "source_api_key_settings_fields": ("novita_api_key",),
+        "source_base_url_settings_fields": ("novita_base_url",),
+        "default_base_url": "https://api.novita.ai/openai",
+        "runtime_api_key_env_key": "ANTHROPIC_API_KEY",
+        "runtime_base_url_env_key": "ANTHROPIC_BASE_URL",
+    },
 }
 
 
@@ -350,6 +359,13 @@ class ConfigResolver:
             return "minimax"
         if lowered.startswith("deepseek-"):
             return "deepseek"
+        if (
+            lowered.startswith("moonshotai/")
+            or lowered.startswith("deepseek/")
+            or lowered.startswith("zai-org/")
+            or lowered.startswith("qwen/")
+        ):
+            return "novita"
         return None
 
     @staticmethod

--- a/frontend/features/settings/components/tabs/models-settings-tab.tsx
+++ b/frontend/features/settings/components/tabs/models-settings-tab.tsx
@@ -48,6 +48,11 @@ const PROVIDER_HELP_INFO: Record<string, ProviderHelpInfo> = {
       "https://platform.claude.com/docs/en/docs/about-claude/models",
     modelDocsName: "Claude",
   },
+  novita: {
+    apiKeyUrl: "https://novita.ai/settings/key-management",
+    modelDocsUrl: "https://novita.ai/docs/api-reference/llm-openai-compatible",
+    modelDocsName: "Novita AI",
+  },
 };
 
 function splitModelDraft(value: string): string[] {


### PR DESCRIPTION
## Summary

- Adds **Novita AI** (`https://api.novita.ai/openai`, OpenAI-compatible endpoint) as a new LLM provider
- Registers four models: `moonshotai/kimi-k2.5` (default), `deepseek/deepseek-v3.2`, `zai-org/glm-5`, `qwen/qwen3-embedding-0.6b`
- API key env var: `NOVITA_API_KEY` / `NOVITA_BASE_URL`

## Changes

| File | Change |
|------|--------|
| `backend/app/services/model_config_service.py` | New `ProviderSpec` entry + `infer_provider_id` rules for Novita model ID prefixes |
| `executor_manager/app/core/settings.py` | `novita_api_key` / `novita_base_url` settings fields |
| `executor_manager/app/services/config_resolver.py` | New `_PROVIDER_RUNTIME_SPECS` entry + `_infer_provider_id` rules |
| `frontend/features/settings/components/tabs/models-settings-tab.tsx` | `PROVIDER_HELP_INFO` entry with API key and docs URLs |

## Test plan

- [ ] Settings UI shows Novita AI provider card with API key input
- [ ] Entering a `NOVITA_API_KEY` saves and resolves `credential_state: "user"`
- [ ] Selecting a Novita model (e.g. `moonshotai/kimi-k2.5`) adds it to the model list
- [ ] Task execution with a Novita model correctly resolves base URL to `https://api.novita.ai/openai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)