### PR TITLE
fix(frontend): align updated project and session types

### DIFF
--- a/frontend/components/shell/sidebar/app-sidebar.tsx
+++ b/frontend/components/shell/sidebar/app-sidebar.tsx
@@ -24,7 +24,10 @@ interface AppSidebarProps {
   onMoveTaskToProject?: (taskId: string, projectId: string | null) => void;
   onToggleTaskPin?: (taskId: string) => void;
   onCreateProject?: (input: ProjectCreateInput) => void;
-  onRenameProject?: (projectId: string, newName: string) => void;
+  onRenameProject?: (
+    projectId: string,
+    updates: Record<string, unknown>,
+  ) => void;
   onDeleteProject?: (projectId: string) => Promise<void> | void;
   onOpenSettings?: (tab?: SettingsTabId) => void;
   onStartOnboarding?: () => void;

--- a/frontend/components/shell/sidebar/main-sidebar.tsx
+++ b/frontend/components/shell/sidebar/main-sidebar.tsx
@@ -37,7 +37,10 @@ interface MainSidebarProps {
   onRenameTask?: (taskId: string, newName: string) => Promise<void> | void;
   onMoveTaskToProject?: (taskId: string, projectId: string | null) => void;
   onToggleTaskPin: (taskId: string) => void;
-  onRenameProject?: (projectId: string, newName: string) => void;
+  onRenameProject?: (
+    projectId: string,
+    updates: Record<string, unknown>,
+  ) => void;
   onDeleteProject?: (projectId: string) => Promise<void> | void;
   onOpenSettings?: (tab?: SettingsTabId) => void;
   onStartOnboarding?: () => void;

--- a/frontend/features/capabilities/presets/components/preset-card-surface.tsx
+++ b/frontend/features/capabilities/presets/components/preset-card-surface.tsx
@@ -48,7 +48,7 @@ export function PresetCardSurface({
       if (!isInteractive) return;
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        onActivate();
+        onActivate?.();
       }
     },
     [isInteractive, onActivate],

--- a/frontend/features/chat/api/chat-api.ts
+++ b/frontend/features/chat/api/chat-api.ts
@@ -62,6 +62,7 @@ function toExecutionSession(
 ): ExecutionSession {
   return {
     session_id: session.session_id,
+    project_id: session.project_id ?? null,
     time: session.updated_at,
     status: session.status as ExecutionSession["status"],
     progress,
@@ -78,6 +79,7 @@ function toExecutionSession(
 function createDefaultSession(sessionId: string): ExecutionSession {
   return {
     session_id: sessionId,
+    project_id: null,
     time: new Date().toISOString(),
     status: "pending",
     progress: 0,

--- a/frontend/features/chat/types/ui/execution.ts
+++ b/frontend/features/chat/types/ui/execution.ts
@@ -82,6 +82,7 @@ export interface StatePatch extends ApiStatePatch {
  */
 export interface ExecutionSession {
   session_id: string;
+  project_id?: string | null;
   time: string;
   status: ExecutionStatus;
   progress: number;

--- a/frontend/features/projects/api/projects-api.ts
+++ b/frontend/features/projects/api/projects-api.ts
@@ -93,8 +93,8 @@ export const projectsService = {
     default_model?: string | null;
     default_preset_id?: number | null;
     local_mounts?: LocalMountConfig[] | null;
-    repo_url?: string;
-    git_branch?: string;
+    repo_url?: string | null;
+    git_branch?: string | null;
     git_token_env_key?: string | null;
   }): Promise<ProjectItem> => {
     const project = await apiClient.post<ProjectApiResponse>(

--- a/frontend/features/projects/components/project-header.tsx
+++ b/frontend/features/projects/components/project-header.tsx
@@ -13,6 +13,7 @@ interface ProjectHeaderProps {
   project?: ProjectItem;
   isDrawerOpen?: boolean;
   onToggleDrawer?: () => void;
+  onOpenSettings?: () => void;
 }
 
 export function ProjectHeader({


### PR DESCRIPTION
- update sidebar project edit callbacks to accept generic project update payloads
- carry project_id through execution session UI mapping for filesystem persistence flows
- relax project API payload typing for nullable repo and branch fields
- add the missing project header settings prop to match current page usage
- guard optional preset card activation handlers to satisfy TypeScript checks