### PR TITLE
fix(docker): add healthchecks for backend, executor-manager, and frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,6 +214,12 @@ services:
       UVICORN_ACCESS_LOG: ${UVICORN_ACCESS_LOG:-false}
     ports:
       - "${BACKEND_PORT:-8000}:8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   executor-manager:
     # Default to pulling from GHCR; override via EXECUTOR_MANAGER_IMAGE if needed.
@@ -222,7 +228,7 @@ services:
     user: "${EXECUTOR_UID:-1000}:${EXECUTOR_GID:-1000}"
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
       rustfs:
         condition: service_started
     environment:
@@ -296,6 +302,12 @@ services:
       - "host.docker.internal:host-gateway"
     ports:
       - "${EXECUTOR_MANAGER_PORT:-8001}:8001"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/api/v1/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   frontend:
     # Default to pulling from GHCR; override via FRONTEND_IMAGE if needed.
@@ -303,7 +315,7 @@ services:
     restart: unless-stopped
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     environment:
       # Runtime backend URL for the Next.js API proxy (/api/v1/* -> backend).
       BACKEND_URL: ${BACKEND_URL:-http://backend:8000}
@@ -311,6 +323,12 @@ services:
       NEXT_PUBLIC_AUTH_COOKIE_NAME: ${NEXT_PUBLIC_AUTH_COOKIE_NAME:-poco_session}
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Background

The `docker-compose.yml` defines healthchecks for infrastructure services (postgres, mem0-postgres, mem0-neo4j) but not for the application services (backend, executor-manager, frontend). Downstream services use `service_started` as their dependency condition, which only waits for the container to start — not for the service to be ready to accept requests.

## Changes

### 1. Add healthchecks to application services

| Service | Method | Endpoint |
|---------|--------|----------|
| backend | `python urllib` | `/api/v1/health` |
| executor-manager | `python urllib` | `/api/v1/health` |
| frontend | `wget --spider` | `/` |

Healthcheck tools were chosen based on what is already available in each base image:
- `python:3.12-slim` → Python stdlib `urllib.request`
- `node:20-alpine` → `wget` (included in Alpine)

### 2. Upgrade depends_on conditions

- **executor-manager** now waits for backend to be `service_healthy` (was `service_started`)
- **frontend** now waits for backend to be `service_healthy` (was `service_started`)

This ensures downstream services only start after backend has completed database migrations and is ready to serve requests.

## Verification

- `docker compose config` validates successfully
- Healthcheck parameters: `interval=10s`, `timeout=5s`, `retries=5`, `start_period=30s`