### PR TITLE
修复 #114 中的状态不一致与任务交互问题

### DIFF
--- a/backend/app/services/agent_assignment_service.py
+++ b/backend/app/services/agent_assignment_service.py
@@ -304,6 +304,17 @@ class AgentAssignmentService:
         )
 
         created = existing is None
+        previous_preset_id = existing.preset_id if existing is not None else None
+        previous_trigger_mode = (
+            existing.trigger_mode if existing is not None else None
+        )
+        config_changed = (
+            existing is not None
+            and (
+                previous_preset_id != preset.id
+                or previous_trigger_mode != mode
+            )
+        )
         assignment = existing or AgentAssignment(
             workspace_id=issue.workspace_id,
             issue_id=issue.id,
@@ -321,7 +332,12 @@ class AgentAssignmentService:
             AgentAssignmentRepository.create(db, assignment)
         else:
             assignment.status = "pending"
-            if existing.preset_id != preset.id or existing.trigger_mode != mode:
+            if config_changed:
+                self._cancel_existing_session(
+                    db,
+                    actor_user_id=current_user.id,
+                    assignment=existing,
+                )
                 assignment.session_id = None
                 assignment.container_id = None
                 assignment.last_triggered_at = None

--- a/backend/app/services/agent_assignment_service.py
+++ b/backend/app/services/agent_assignment_service.py
@@ -305,15 +305,9 @@ class AgentAssignmentService:
 
         created = existing is None
         previous_preset_id = existing.preset_id if existing is not None else None
-        previous_trigger_mode = (
-            existing.trigger_mode if existing is not None else None
-        )
-        config_changed = (
-            existing is not None
-            and (
-                previous_preset_id != preset.id
-                or previous_trigger_mode != mode
-            )
+        previous_trigger_mode = existing.trigger_mode if existing is not None else None
+        config_changed = existing is not None and (
+            previous_preset_id != preset.id or previous_trigger_mode != mode
         )
         assignment = existing or AgentAssignment(
             workspace_id=issue.workspace_id,

--- a/backend/app/services/agent_identity_service.py
+++ b/backend/app/services/agent_identity_service.py
@@ -31,6 +31,7 @@ from app.schemas.agent_identity import (
     ChannelAgentMemberCreateRequest,
     ChannelAgentMemberResponse,
 )
+from app.services.agent_runtime_service import AgentRuntimeService
 from app.services.agent_state_bootstrap_service import ensure_agent_state_bootstrap
 from app.services.server_channel_access import require_channel_member_access
 from app.services.server_member_service import (
@@ -47,11 +48,25 @@ from app.services.session_service import SessionService
 
 
 class AgentIdentityService:
-    def __init__(self, *, session_service: SessionService | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        session_service: SessionService | None = None,
+        runtime_service: AgentRuntimeService | None = None,
+    ) -> None:
         self._session_service = session_service or SessionService()
+        self._runtime_service = runtime_service or AgentRuntimeService()
 
-    @staticmethod
-    def _to_agent_response(agent_identity: AgentIdentity) -> AgentIdentityResponse:
+    def _to_agent_response(
+        self,
+        db: Session,
+        agent_identity: AgentIdentity,
+    ) -> AgentIdentityResponse:
+        if agent_identity.persistent_state is not None:
+            self._runtime_service.reconcile_persistent_state(
+                db,
+                agent_identity.persistent_state,
+            )
         return AgentIdentityResponse.model_validate(agent_identity)
 
     @staticmethod
@@ -108,7 +123,7 @@ class AgentIdentityService:
     ) -> list[AgentIdentityResponse]:
         require_server_member(db, server_id, current_user.id)
         return [
-            self._to_agent_response(item)
+            self._to_agent_response(db, item)
             for item in AgentIdentityRepository.list_by_server(
                 db,
                 server_id,
@@ -130,7 +145,7 @@ class AgentIdentityService:
                 error_code=ErrorCode.NOT_FOUND,
                 message=f"Agent identity not found: {agent_identity_id}",
             )
-        return self._to_agent_response(agent_identity)
+        return self._to_agent_response(db, agent_identity)
 
     def create_agent(
         self,
@@ -205,7 +220,7 @@ class AgentIdentityService:
             AgentIdentity,
             AgentIdentityRepository.get_by_id(db, agent_identity.id),
         )
-        return self._to_agent_response(agent_identity)
+        return self._to_agent_response(db, agent_identity)
 
     def update_agent(
         self,
@@ -232,7 +247,7 @@ class AgentIdentityService:
         agent_identity.updated_by = current_user.id
         db.commit()
         db.refresh(agent_identity)
-        return self._to_agent_response(agent_identity)
+        return self._to_agent_response(db, agent_identity)
 
     def list_channel_agents(
         self,
@@ -260,7 +275,7 @@ class AgentIdentityService:
                 continue
             if self._is_removed(agent_identity):
                 continue
-            agent_responses.append(self._to_agent_response(agent_identity))
+            agent_responses.append(self._to_agent_response(db, agent_identity))
         return agent_responses
 
     def add_agent_to_channel(
@@ -462,7 +477,7 @@ class AgentIdentityService:
             agent_identity.persistent_state.active_task_id = None
         db.commit()
         db.refresh(agent_identity)
-        return self._to_agent_response(agent_identity)
+        return self._to_agent_response(db, agent_identity)
 
     def stop_agent(
         self,
@@ -491,7 +506,7 @@ class AgentIdentityService:
             agent_identity.persistent_state.active_task_id = None
         db.commit()
         db.refresh(agent_identity)
-        return self._to_agent_response(agent_identity)
+        return self._to_agent_response(db, agent_identity)
 
     def _require_owner_agent(
         self,

--- a/backend/app/services/agent_runtime_service.py
+++ b/backend/app/services/agent_runtime_service.py
@@ -9,9 +9,65 @@ from app.models.agent_persistent_state import AgentPersistentState
 from app.repositories.agent_persistent_state_repository import (
     AgentPersistentStateRepository,
 )
+from app.repositories.run_repository import RunRepository
+from app.repositories.session_queue_item_repository import (
+    SessionQueueItemRepository,
+)
+from app.repositories.session_repository import SessionRepository
 
 
 class AgentRuntimeService:
+    LIVE_SESSION_STATUSES = {"pending", "running", "canceling"}
+
+    @classmethod
+    def _session_has_live_work(cls, db: Session, session_id: uuid.UUID) -> bool:
+        session = SessionRepository.get_by_id(db, session_id)
+        if session is not None and session.status in cls.LIVE_SESSION_STATUSES:
+            return True
+        if RunRepository.get_blocking_by_session(db, session_id) is not None:
+            return True
+        return SessionQueueItemRepository.has_active_items(db, session_id)
+
+    @staticmethod
+    def _terminal_runtime_status(db: Session, session_id: uuid.UUID) -> str:
+        session = SessionRepository.get_by_id(db, session_id)
+        if session is not None and session.status == "failed":
+            return "failed"
+        latest_terminal_run = RunRepository.get_latest_terminal_by_session(db, session_id)
+        if latest_terminal_run is not None and latest_terminal_run.status == "failed":
+            return "failed"
+        return "idle"
+
+    @staticmethod
+    def _clear_runtime_binding(
+        state: AgentPersistentState,
+        *,
+        runtime_status: str,
+    ) -> AgentPersistentState:
+        now = datetime.now(timezone.utc)
+        state.runtime_status = runtime_status
+        state.active_session_id = None
+        state.active_task_id = None
+        state.last_synced_at = now
+        state.last_written_at = now
+        return state
+
+    def reconcile_persistent_state(
+        self,
+        db: Session,
+        state: AgentPersistentState,
+    ) -> AgentPersistentState:
+        if state.runtime_status != "busy":
+            return state
+        if state.active_session_id is None:
+            return self._clear_runtime_binding(state, runtime_status="idle")
+        if self._session_has_live_work(db, state.active_session_id):
+            return state
+        return self._clear_runtime_binding(
+            state,
+            runtime_status=self._terminal_runtime_status(db, state.active_session_id),
+        )
+
     @staticmethod
     def get_persistent_state(
         db: Session,
@@ -26,7 +82,7 @@ class AgentRuntimeService:
                 error_code=ErrorCode.NOT_FOUND,
                 message=f"Agent persistent state not found: {agent_identity_id}",
             )
-        return state
+        return AgentRuntimeService().reconcile_persistent_state(db, state)
 
     def reserve_persistent_runtime(
         self,
@@ -69,11 +125,10 @@ class AgentRuntimeService:
 
         normalized = (callback_status or "").strip().lower()
         if normalized == "failed":
-            state.runtime_status = "failed"
-        else:
-            state.runtime_status = "idle"
-        state.active_session_id = None
-        state.active_task_id = None
-        state.last_synced_at = datetime.now(timezone.utc)
-        state.last_written_at = datetime.now(timezone.utc)
-        return state
+            return self._clear_runtime_binding(state, runtime_status="failed")
+        if self._session_has_live_work(db, session_id):
+            state.runtime_status = "busy"
+            state.active_session_id = session_id
+            state.last_synced_at = datetime.now(timezone.utc)
+            return state
+        return self._clear_runtime_binding(state, runtime_status="idle")

--- a/backend/app/services/agent_runtime_service.py
+++ b/backend/app/services/agent_runtime_service.py
@@ -33,7 +33,9 @@ class AgentRuntimeService:
         session = SessionRepository.get_by_id(db, session_id)
         if session is not None and session.status == "failed":
             return "failed"
-        latest_terminal_run = RunRepository.get_latest_terminal_by_session(db, session_id)
+        latest_terminal_run = RunRepository.get_latest_terminal_by_session(
+            db, session_id
+        )
         if latest_terminal_run is not None and latest_terminal_run.status == "failed":
             return "failed"
         return "idle"

--- a/backend/app/services/preset_service.py
+++ b/backend/app/services/preset_service.py
@@ -1,14 +1,18 @@
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from app.models.agent_assignment import AgentAssignment
+from app.models.agent_identity import AgentIdentity
 from app.core.errors.error_codes import ErrorCode
 from app.core.errors.exceptions import AppException
 from app.models.mcp_server import McpServer
 from app.models.plugin import Plugin
 from app.models.preset import Preset
 from app.models.preset_visual import PresetVisual
+from app.models.server_channel_task import ServerChannelTask
 from app.models.skill import Skill
 from app.repositories.mcp_server_repository import McpServerRepository
 from app.repositories.plugin_repository import PluginRepository
@@ -288,11 +292,12 @@ class PresetService:
                 message="Cannot delete system presets",
             )
 
-        usage_count = PresetRepository.count_projects_using_as_default(db, preset_id)
-        if usage_count > 0:
+        dependencies = self._collect_delete_dependencies(db, preset_id)
+        if dependencies:
             raise AppException(
                 error_code=ErrorCode.BAD_REQUEST,
-                message="Preset is still used as a project default preset",
+                message="Preset is still referenced by active resources",
+                details={"dependencies": dependencies},
             )
 
         PresetRepository.soft_delete(db, preset)
@@ -336,6 +341,71 @@ class PresetService:
             db, user_id=user_id, mcp_server_ids=mcp_server_ids
         )
         self._validate_visible_plugins(db, user_id=user_id, plugin_ids=plugin_ids)
+
+    @staticmethod
+    def _collect_delete_dependencies(
+        db: Session,
+        preset_id: int,
+    ) -> list[dict[str, int | str]]:
+        dependencies: list[dict[str, int | str]] = []
+
+        project_default_count = PresetRepository.count_projects_using_as_default(
+            db, preset_id
+        )
+        if project_default_count > 0:
+            dependencies.append(
+                {"type": "project_default", "count": project_default_count}
+            )
+
+        live_agent_identity_count = (
+            db.query(AgentIdentity)
+            .filter(
+                AgentIdentity.preset_id == preset_id,
+                AgentIdentity.removed_at.is_(None),
+            )
+            .count()
+        )
+        if live_agent_identity_count > 0:
+            dependencies.append(
+                {
+                    "type": "live_agent_identity",
+                    "count": live_agent_identity_count,
+                }
+            )
+
+        active_assignment_count = (
+            db.query(AgentAssignment)
+            .filter(
+                AgentAssignment.preset_id == preset_id,
+                or_(
+                    AgentAssignment.status.in_(("pending", "running")),
+                    AgentAssignment.trigger_mode == "scheduled_task",
+                ),
+            )
+            .count()
+        )
+        if active_assignment_count > 0:
+            dependencies.append(
+                {"type": "active_assignment", "count": active_assignment_count}
+            )
+
+        channel_task_assignee_count = (
+            db.query(ServerChannelTask)
+            .filter(
+                ServerChannelTask.assignee_preset_id == preset_id,
+                ServerChannelTask.status != "done",
+            )
+            .count()
+        )
+        if channel_task_assignee_count > 0:
+            dependencies.append(
+                {
+                    "type": "channel_task_assignee",
+                    "count": channel_task_assignee_count,
+                }
+            )
+
+        return dependencies
 
     @staticmethod
     def _normalize_optional_str(value: str | None) -> str | None:

--- a/backend/app/services/server_channel_task_service.py
+++ b/backend/app/services/server_channel_task_service.py
@@ -11,6 +11,7 @@ from app.models.server_channel_message import ServerChannelMessage
 from app.models.server_channel_task import ServerChannelTask
 from app.models.user import User
 from app.repositories.agent_identity_repository import AgentIdentityRepository
+from app.repositories.preset_repository import PresetRepository
 from app.repositories.server_channel_message_repository import (
     ServerChannelMessageRepository,
 )
@@ -263,13 +264,29 @@ class ServerChannelTaskService:
                 message="Task assignee agent must be an active channel member",
             )
 
+    @staticmethod
+    def _validate_preset_assignee(
+        db: Session,
+        *,
+        user_id: str,
+        preset_id: int,
+    ) -> None:
+        preset = PresetRepository.get_visible_by_id(db, preset_id, user_id)
+        if preset is None:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="Task assignee preset is not available",
+            )
+
     def _validate_task_assignee(
         self,
         db: Session,
         *,
+        current_user_id: str,
         server_id: uuid.UUID,
         channel_id: uuid.UUID,
         assignee_user_id: str | None,
+        assignee_preset_id: int | None,
         assignee_agent_identity_id: uuid.UUID | None,
     ) -> None:
         if assignee_user_id is not None:
@@ -277,6 +294,12 @@ class ServerChannelTaskService:
                 db,
                 server_id=server_id,
                 user_id=assignee_user_id,
+            )
+        if assignee_preset_id is not None:
+            self._validate_preset_assignee(
+                db,
+                user_id=current_user_id,
+                preset_id=assignee_preset_id,
             )
         if assignee_agent_identity_id is not None:
             self._validate_agent_assignee(
@@ -577,9 +600,11 @@ class ServerChannelTaskService:
         self._validate_status(request.status)
         self._validate_task_assignee(
             db,
+            current_user_id=current_user.id,
             server_id=server_id,
             channel_id=channel.id,
             assignee_user_id=request.assignee_user_id,
+            assignee_preset_id=request.assignee_preset_id,
             assignee_agent_identity_id=request.assignee_agent_identity_id,
         )
         activity_thread_root_message_id = self._resolve_task_thread_root_message_id(
@@ -707,9 +732,11 @@ class ServerChannelTaskService:
         ):
             self._validate_task_assignee(
                 db,
+                current_user_id=current_user.id,
                 server_id=server_id,
                 channel_id=channel_id,
                 assignee_user_id=request.assignee_user_id,
+                assignee_preset_id=request.assignee_preset_id,
                 assignee_agent_identity_id=request.assignee_agent_identity_id,
             )
             task.assignee_user_id = request.assignee_user_id
@@ -837,9 +864,11 @@ class ServerChannelTaskService:
             assignee_agent_identity_id = actor_context.actor_agent_identity_id
         self._validate_task_assignee(
             db,
+            current_user_id=current_user.id,
             server_id=server_id,
             channel_id=channel_id,
             assignee_user_id=assignee_user_id,
+            assignee_preset_id=assignee_preset_id,
             assignee_agent_identity_id=assignee_agent_identity_id,
         )
         task.assignee_user_id = assignee_user_id

--- a/backend/tests/test_agent_assignment_service.py
+++ b/backend/tests/test_agent_assignment_service.py
@@ -90,6 +90,187 @@ class AgentAssignmentServiceTests(unittest.TestCase):
         )
         enqueue_run.assert_called_once()
 
+    def test_sync_issue_assignment_resets_runtime_when_preset_changes(self) -> None:
+        db = MagicMock()
+        issue = WorkspaceIssue(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            board_id=uuid.uuid4(),
+            title="Harden retries",
+            description="Retry external calls.",
+            status="in_progress",
+            type="task",
+            priority="high",
+            assignee_preset_id=5,
+            creator_user_id="user-1",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        current_user = User(
+            id="user-1",
+            primary_email="alice@example.com",
+            display_name="Alice",
+            avatar_url=None,
+            status="active",
+        )
+        existing = MagicMock(
+            workspace_id=issue.workspace_id,
+            issue_id=issue.id,
+            preset_id=5,
+            trigger_mode="persistent_sandbox",
+            prompt="Existing prompt",
+            created_by="user-1",
+            status="running",
+            session_id=uuid.uuid4(),
+            container_id="exec-old",
+            last_triggered_at=datetime.now(UTC),
+            last_completed_at=datetime.now(UTC),
+            schedule_cron=None,
+        )
+        next_preset = Preset(
+            id=9,
+            user_id="user-1",
+            name="Reviewer",
+            visual_key="preset-visual-02",
+            prompt_template="",
+            browser_enabled=False,
+            memory_enabled=False,
+            container_mode="persistent",
+            skill_ids=[],
+            mcp_server_ids=[],
+            plugin_ids=[],
+            subagent_configs=[],
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        service = AgentAssignmentService(task_service=MagicMock())
+
+        with (
+            patch(
+                "app.services.agent_assignment_service.AgentAssignmentRepository.get_by_issue_id",
+                return_value=existing,
+            ),
+            patch(
+                "app.services.agent_assignment_service.PresetRepository.get_visible_by_id",
+                return_value=next_preset,
+            ),
+            patch.object(
+                service._prompt_builder,
+                "build_issue_prompt",
+                return_value="Harden retries\n\nRetry external calls.",
+            ),
+        ):
+            assignment = service.sync_issue_assignment(
+                db,
+                current_user=current_user,
+                issue=issue,
+                preset_id=9,
+                trigger_mode="persistent_sandbox",
+                schedule_cron=None,
+                prompt_override=None,
+                auto_trigger=False,
+            )
+
+        self.assertIs(assignment, existing)
+        self.assertEqual(assignment.preset_id, 9)
+        self.assertIsNone(assignment.session_id)
+        self.assertIsNone(assignment.container_id)
+        self.assertIsNone(assignment.last_triggered_at)
+        self.assertIsNone(assignment.last_completed_at)
+
+    def test_sync_issue_assignment_resets_runtime_when_trigger_mode_changes(
+        self,
+    ) -> None:
+        db = MagicMock()
+        issue = WorkspaceIssue(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            board_id=uuid.uuid4(),
+            title="Schedule reviews",
+            description="Run every morning.",
+            status="in_progress",
+            type="task",
+            priority="high",
+            assignee_preset_id=5,
+            creator_user_id="user-1",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        current_user = User(
+            id="user-1",
+            primary_email="alice@example.com",
+            display_name="Alice",
+            avatar_url=None,
+            status="active",
+        )
+        existing = MagicMock(
+            workspace_id=issue.workspace_id,
+            issue_id=issue.id,
+            preset_id=5,
+            trigger_mode="persistent_sandbox",
+            prompt="Existing prompt",
+            created_by="user-1",
+            status="running",
+            session_id=uuid.uuid4(),
+            container_id="exec-old",
+            last_triggered_at=datetime.now(UTC),
+            last_completed_at=datetime.now(UTC),
+            schedule_cron=None,
+        )
+        preset = Preset(
+            id=5,
+            user_id="user-1",
+            name="Reviewer",
+            visual_key="preset-visual-02",
+            prompt_template="",
+            browser_enabled=False,
+            memory_enabled=False,
+            container_mode="persistent",
+            skill_ids=[],
+            mcp_server_ids=[],
+            plugin_ids=[],
+            subagent_configs=[],
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        service = AgentAssignmentService(task_service=MagicMock())
+
+        with (
+            patch(
+                "app.services.agent_assignment_service.AgentAssignmentRepository.get_by_issue_id",
+                return_value=existing,
+            ),
+            patch(
+                "app.services.agent_assignment_service.PresetRepository.get_visible_by_id",
+                return_value=preset,
+            ),
+            patch.object(
+                service._prompt_builder,
+                "build_issue_prompt",
+                return_value="Schedule reviews\n\nRun every morning.",
+            ),
+        ):
+            assignment = service.sync_issue_assignment(
+                db,
+                current_user=current_user,
+                issue=issue,
+                preset_id=5,
+                trigger_mode="scheduled_task",
+                schedule_cron="0 9 * * *",
+                prompt_override=None,
+                auto_trigger=False,
+            )
+
+        self.assertIs(assignment, existing)
+        self.assertEqual(assignment.trigger_mode, "scheduled_task")
+        self.assertEqual(assignment.schedule_cron, "0 9 * * *")
+        self.assertIsNone(assignment.session_id)
+        self.assertIsNone(assignment.container_id)
+        self.assertIsNone(assignment.last_triggered_at)
+        self.assertIsNone(assignment.last_completed_at)
+
     def test_sync_callback_status_marks_issue_done(self) -> None:
         db = MagicMock()
         session_id = uuid.uuid4()

--- a/backend/tests/test_agent_runtime_service.py
+++ b/backend/tests/test_agent_runtime_service.py
@@ -1,8 +1,10 @@
 import unittest
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from app.services import agent_runtime_service as agent_runtime_service_module
 from app.models.agent_persistent_state import AgentPersistentState
 from app.services.agent_runtime_service import AgentRuntimeService
 
@@ -62,11 +64,144 @@ class AgentRuntimeServiceTests(unittest.TestCase):
         )
         db.query.return_value.filter.return_value.first.return_value = state
 
-        result = AgentRuntimeService().release_runtime_for_session(
-            db,
-            session_id=session_id,
-            callback_status="completed",
+        with (
+            patch.object(
+                agent_runtime_service_module,
+                "SessionRepository",
+                create=True,
+            ) as session_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "RunRepository",
+                create=True,
+            ) as run_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "SessionQueueItemRepository",
+                create=True,
+            ) as queue_repo,
+        ):
+            session_repo.get_by_id.return_value = None
+            run_repo.get_blocking_by_session.return_value = None
+            queue_repo.has_active_items.return_value = False
+            result = AgentRuntimeService().release_runtime_for_session(
+                db,
+                session_id=session_id,
+                callback_status="completed",
+            )
+
+        self.assertIs(result, state)
+        self.assertEqual(state.runtime_status, "idle")
+        self.assertIsNone(state.active_session_id)
+        self.assertIsNone(state.active_task_id)
+
+    def test_release_runtime_for_session_keeps_busy_with_followup_work(self) -> None:
+        db = MagicMock()
+        session_id = uuid.uuid4()
+        state = AgentPersistentState(
+            id=uuid.uuid4(),
+            agent_identity_id=uuid.uuid4(),
+            state_root_path="agents/demo",
+            profile_path="agents/demo/profile.json",
+            memory_path="agents/demo/MEMORY.md",
+            notes_dir_path="agents/demo/notes",
+            state_dir_path="agents/demo/state",
+            artifacts_dir_path="agents/demo/artifacts",
+            state_version=1,
+            runtime_status="busy",
+            active_task_id=uuid.uuid4(),
+            active_session_id=session_id,
+            last_synced_at=None,
+            last_written_at=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
+        db.query.return_value.filter.return_value.first.return_value = state
+
+        with (
+            patch.object(
+                agent_runtime_service_module,
+                "SessionRepository",
+                create=True,
+            ) as session_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "RunRepository",
+                create=True,
+            ) as run_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "SessionQueueItemRepository",
+                create=True,
+            ) as queue_repo,
+        ):
+            session_repo.get_by_id.return_value = SimpleNamespace(
+                id=session_id, status="pending"
+            )
+            run_repo.get_blocking_by_session.return_value = MagicMock()
+            queue_repo.has_active_items.return_value = False
+            result = AgentRuntimeService().release_runtime_for_session(
+                db,
+                session_id=session_id,
+                callback_status="completed",
+            )
+
+        self.assertIs(result, state)
+        self.assertEqual(state.runtime_status, "busy")
+        self.assertEqual(state.active_session_id, session_id)
+
+    def test_get_persistent_state_reconciles_stale_busy_session(self) -> None:
+        db = MagicMock()
+        session_id = uuid.uuid4()
+        state = AgentPersistentState(
+            id=uuid.uuid4(),
+            agent_identity_id=uuid.uuid4(),
+            state_root_path="agents/demo",
+            profile_path="agents/demo/profile.json",
+            memory_path="agents/demo/MEMORY.md",
+            notes_dir_path="agents/demo/notes",
+            state_dir_path="agents/demo/state",
+            artifacts_dir_path="agents/demo/artifacts",
+            state_version=1,
+            runtime_status="busy",
+            active_task_id=uuid.uuid4(),
+            active_session_id=session_id,
+            last_synced_at=None,
+            last_written_at=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        with (
+            patch(
+                "app.services.agent_runtime_service.AgentPersistentStateRepository.get_by_agent_identity_id",
+                return_value=state,
+            ),
+            patch.object(
+                agent_runtime_service_module,
+                "SessionRepository",
+                create=True,
+            ) as session_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "RunRepository",
+                create=True,
+            ) as run_repo,
+            patch.object(
+                agent_runtime_service_module,
+                "SessionQueueItemRepository",
+                create=True,
+            ) as queue_repo,
+        ):
+            session_repo.get_by_id.return_value = SimpleNamespace(
+                id=session_id, status="completed"
+            )
+            run_repo.get_blocking_by_session.return_value = None
+            queue_repo.has_active_items.return_value = False
+            result = AgentRuntimeService().get_persistent_state(
+                db,
+                state.agent_identity_id,
+            )
 
         self.assertIs(result, state)
         self.assertEqual(state.runtime_status, "idle")

--- a/backend/tests/test_preset_services.py
+++ b/backend/tests/test_preset_services.py
@@ -20,11 +20,11 @@ class PresetServiceTests(unittest.TestCase):
         self.user_id = "user-1"
         self.now = datetime.now(UTC)
 
-    @patch("app.services.preset_service.PresetRepository.exists_by_user_name")
+    @patch("app.services.preset_service.PresetRepository.exists_by_scope_name")
     def test_create_preset_rejects_duplicate_name(
-        self, exists_by_user_name: MagicMock
+        self, exists_by_scope_name: MagicMock
     ) -> None:
-        exists_by_user_name.return_value = True
+        exists_by_scope_name.return_value = True
 
         with self.assertRaises(AppException) as context:
             self.service.create_preset(
@@ -37,20 +37,26 @@ class PresetServiceTests(unittest.TestCase):
             )
 
         self.assertEqual(context.exception.error_code, ErrorCode.PRESET_ALREADY_EXISTS)
-        exists_by_user_name.assert_called_once_with(self.db, self.user_id, "Frontend")
+        exists_by_scope_name.assert_called_once_with(
+            self.db,
+            scope="personal",
+            name="Frontend",
+            user_id=self.user_id,
+            workspace_id=None,
+        )
 
     @patch.object(PresetService, "_validate_components")
     @patch("app.services.preset_service.PresetVisualRepository.get_by_key")
     @patch("app.services.preset_service.PresetRepository.create")
-    @patch("app.services.preset_service.PresetRepository.exists_by_user_name")
+    @patch("app.services.preset_service.PresetRepository.exists_by_scope_name")
     def test_create_preset_persists_trimmed_fields(
         self,
-        exists_by_user_name: MagicMock,
+        exists_by_scope_name: MagicMock,
         create: MagicMock,
         get_visual_by_key: MagicMock,
         validate_components: MagicMock,
     ) -> None:
-        exists_by_user_name.return_value = False
+        exists_by_scope_name.return_value = False
         get_visual_by_key.return_value = PresetVisual(
             id=1,
             key="preset-visual-01",
@@ -111,12 +117,12 @@ class PresetServiceTests(unittest.TestCase):
         self.assertEqual(result.visual_version, "abc123")
 
     @patch.object(PresetService, "_validate_components")
-    @patch("app.services.preset_service.PresetRepository.exists_by_user_name")
+    @patch("app.services.preset_service.PresetRepository.exists_by_scope_name")
     @patch("app.services.preset_service.PresetRepository.get_by_id")
     def test_update_preset_rejects_blank_name(
         self,
         get_by_id: MagicMock,
-        exists_by_user_name: MagicMock,
+        exists_by_scope_name: MagicMock,
         validate_components: MagicMock,
     ) -> None:
         get_by_id.return_value = Preset(
@@ -136,7 +142,7 @@ class PresetServiceTests(unittest.TestCase):
             created_at=self.now,
             updated_at=self.now,
         )
-        exists_by_user_name.return_value = False
+        exists_by_scope_name.return_value = False
 
         with self.assertRaises(AppException) as context:
             self.service.update_preset(
@@ -176,6 +182,10 @@ class PresetServiceTests(unittest.TestCase):
             updated_at=self.now,
         )
         count_projects_using_as_default.return_value = 2
+        query_mocks = [MagicMock(), MagicMock(), MagicMock()]
+        for query_mock in query_mocks:
+            query_mock.filter.return_value.count.return_value = 0
+        self.db.query.side_effect = query_mocks
 
         with self.assertRaises(AppException) as context:
             self.service.delete_preset(self.db, self.user_id, 9)
@@ -183,14 +193,63 @@ class PresetServiceTests(unittest.TestCase):
         self.assertEqual(context.exception.error_code, ErrorCode.BAD_REQUEST)
         self.db.commit.assert_not_called()
 
-    @patch("app.services.preset_service.PresetRepository.exists_by_user_name")
+    @patch(
+        "app.services.preset_service.PresetRepository.count_projects_using_as_default"
+    )
+    @patch("app.services.preset_service.PresetRepository.get_by_id")
+    def test_delete_preset_rejects_live_agent_and_assignment_references(
+        self,
+        get_by_id: MagicMock,
+        count_projects_using_as_default: MagicMock,
+    ) -> None:
+        get_by_id.return_value = Preset(
+            id=9,
+            user_id=self.user_id,
+            name="Shared",
+            description=None,
+            visual_key="preset-visual-01",
+            prompt_template=None,
+            browser_enabled=False,
+            memory_enabled=False,
+            skill_ids=[],
+            mcp_server_ids=[],
+            plugin_ids=[],
+            subagent_configs=[],
+            is_deleted=False,
+            created_at=self.now,
+            updated_at=self.now,
+        )
+        count_projects_using_as_default.return_value = 0
+        query_mocks = [MagicMock(), MagicMock(), MagicMock()]
+        query_mocks[0].filter.return_value.count.return_value = 2
+        query_mocks[1].filter.return_value.count.return_value = 1
+        query_mocks[2].filter.return_value.count.return_value = 3
+        self.db.query.side_effect = query_mocks
+
+        with self.assertRaises(AppException) as context:
+            self.service.delete_preset(self.db, self.user_id, 9)
+
+        self.assertEqual(context.exception.error_code, ErrorCode.BAD_REQUEST)
+        self.assertEqual(
+            context.exception.details,
+            {
+                "dependencies": [
+                    {"type": "live_agent_identity", "count": 2},
+                    {"type": "active_assignment", "count": 1},
+                    {"type": "channel_task_assignee", "count": 3},
+                ]
+            },
+        )
+        self.db.commit.assert_not_called()
+
+    @patch("app.services.preset_service.PresetRepository.exists_by_scope_name")
     @patch("app.services.preset_service.PresetVisualRepository.get_by_key")
     def test_create_preset_rejects_unknown_visual_key(
         self,
         get_visual_by_key: MagicMock,
-        exists_by_user_name: MagicMock,
+        exists_by_scope_name: MagicMock,
     ) -> None:
-        exists_by_user_name.return_value = False
+        exists_by_scope_name.return_value = False
         get_visual_by_key.return_value = None
 
         with self.assertRaises(AppException) as context:

--- a/backend/tests/test_server_channel_task_service.py
+++ b/backend/tests/test_server_channel_task_service.py
@@ -3,6 +3,8 @@ import uuid
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+from app.core.errors.error_codes import ErrorCode
+from app.core.errors.exceptions import AppException
 from app.models.server_channel import ServerChannel
 from app.models.server_channel_message import ServerChannelMessage
 from app.models.server_channel_task import ServerChannelTask
@@ -12,6 +14,7 @@ from app.schemas.server_channel_task import (
     ServerChannelTaskCreateRequest,
     ServerChannelTaskStatusUpdateRequest,
 )
+from app.services import server_channel_task_service as server_channel_task_module
 from app.services.server_channel_task_service import ServerChannelTaskService
 
 
@@ -83,6 +86,56 @@ class ServerChannelTaskServiceTests(unittest.TestCase):
         self.assertEqual(created_task.title, "Refactor channel task detail")
         self.assertEqual(result.channel_id, self.channel.id)
         self.db.commit.assert_called_once()
+
+    def test_create_task_rejects_invisible_preset_assignee(self) -> None:
+        service = ServerChannelTaskService()
+
+        with (
+            patch.object(service, "_require_channel_access", return_value=self.channel),
+            patch(
+                "app.services.server_channel_task_service.ServerChannelTaskRepository.list_by_channel_and_status",
+                return_value=[],
+            ),
+            patch(
+                "app.services.server_channel_task_service.ServerChannelTaskRepository.create"
+            ) as create_task,
+            patch(
+                "app.services.server_channel_task_service.ServerChannelTaskRepository.get_max_display_number",
+                return_value=None,
+            ),
+            patch.object(service, "_create_task_root_message") as create_root_message,
+            patch.object(
+                server_channel_task_module,
+                "PresetRepository",
+                create=True,
+            ) as preset_repo,
+        ):
+            now = datetime.now(UTC)
+
+            def build_task(_db, task):
+                task.id = uuid.uuid4()
+                task.created_at = now
+                task.updated_at = now
+                return task
+
+            create_task.side_effect = build_task
+            create_root_message.return_value = MagicMock(id=uuid.uuid4())
+            preset_repo.get_visible_by_id.return_value = None
+            with self.assertRaises(AppException) as context:
+                service.create_task(
+                    self.db,
+                    self.user,
+                    self.server_id,
+                    self.channel.id,
+                    ServerChannelTaskCreateRequest(
+                        title="Refactor channel task detail",
+                        assignee_preset_id=7,
+                    ),
+                )
+
+        self.assertEqual(context.exception.error_code, ErrorCode.BAD_REQUEST)
+        self.assertIn("preset", context.exception.message.lower())
+        preset_repo.get_visible_by_id.assert_called_once_with(self.db, 7, self.user.id)
 
     def test_create_task_root_message_is_event_without_author(self) -> None:
         service = ServerChannelTaskService()
@@ -309,6 +362,51 @@ class ServerChannelTaskServiceTests(unittest.TestCase):
         )
         self.assertEqual(result.status, "in_review")
         self.db.commit.assert_called_once()
+
+    def test_claim_task_rejects_invisible_preset_assignee(self) -> None:
+        service = ServerChannelTaskService()
+        task = ServerChannelTask(
+            id=uuid.uuid4(),
+            server_id=self.server_id,
+            channel_id=self.channel.id,
+            display_number=1,
+            title="Ship board view",
+            description=None,
+            status="todo",
+            position=0,
+            priority="medium",
+            creator_user_id="user-1",
+            updated_by="user-1",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        with (
+            patch.object(
+                service,
+                "_require_task_access",
+                return_value=(self.channel, task),
+            ),
+            patch.object(
+                server_channel_task_module,
+                "PresetRepository",
+                create=True,
+            ) as preset_repo,
+        ):
+            preset_repo.get_visible_by_id.return_value = None
+            with self.assertRaises(AppException) as context:
+                service.claim_task(
+                    self.db,
+                    self.user,
+                    self.server_id,
+                    self.channel.id,
+                    task.id,
+                    ServerChannelTaskClaimRequest(assignee_preset_id=7),
+                )
+
+        self.assertEqual(context.exception.error_code, ErrorCode.BAD_REQUEST)
+        self.assertIn("preset", context.exception.message.lower())
+        preset_repo.get_visible_by_id.assert_called_once_with(self.db, 7, self.user.id)
 
     def test_task_status_system_message_helper_creates_event_reply(self) -> None:
         service = ServerChannelTaskService()

--- a/frontend/features/capabilities/presets/hooks/use-preset-catalog.ts
+++ b/frontend/features/capabilities/presets/hooks/use-preset-catalog.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
+import { ApiError } from "@/lib/errors";
 import { useT } from "@/lib/i18n/client";
 import { presetsService } from "@/features/capabilities/presets/api/presets-api";
 import type {
@@ -78,6 +79,38 @@ export function usePresetCatalog() {
     [t],
   );
 
+  const formatDeleteFailure = useCallback(
+    (error: unknown): string => {
+      if (!(error instanceof ApiError)) {
+        return t("library.presetsPage.toasts.deleteFailed");
+      }
+      const payload = error.details as
+        | {
+            data?: {
+              dependencies?: Array<{
+                type?: string;
+                count?: number;
+              }>;
+            };
+          }
+        | undefined;
+      const dependencies = payload?.data?.dependencies;
+      if (!Array.isArray(dependencies) || dependencies.length === 0) {
+        return t("library.presetsPage.toasts.deleteFailed");
+      }
+      const labels = dependencies.map((dependency) =>
+        t(
+          `library.presetsPage.deleteDependencies.${dependency.type ?? "unknown"}`,
+          { count: dependency.count ?? 0 },
+        ),
+      );
+      return t("library.presetsPage.toasts.deleteBlocked", {
+        dependencies: labels.join(", "),
+      });
+    },
+    [t],
+  );
+
   const deletePreset = useCallback(
     async (presetId: number) => {
       setSavingKey(String(presetId));
@@ -89,12 +122,12 @@ export function usePresetCatalog() {
         toast.success(t("library.presetsPage.toasts.deleted"));
       } catch (error) {
         console.error("[Presets] delete failed:", error);
-        toast.error(t("library.presetsPage.toasts.deleteFailed"));
+        toast.error(formatDeleteFailure(error));
       } finally {
         setSavingKey(null);
       }
     },
-    [t],
+    [formatDeleteFailure, t],
   );
 
   return {

--- a/frontend/features/servers/lib/agent-runtime-status.test.ts
+++ b/frontend/features/servers/lib/agent-runtime-status.test.ts
@@ -4,7 +4,9 @@ import assert from "node:assert/strict";
 import { getAgentRuntimeStatus } from "./agent-runtime-status.ts";
 import type { ServerAgentItem } from "../model/types.ts";
 
-function createAgent(overrides: Partial<ServerAgentItem> = {}): ServerAgentItem {
+function createAgent(
+  overrides: Partial<ServerAgentItem> = {},
+): ServerAgentItem {
   return {
     id: "agent-1",
     serverId: "server-1",
@@ -44,7 +46,10 @@ test("maps idle runtime to the shared idle presentation", () => {
   const status = getAgentRuntimeStatus(createAgent());
 
   assert.equal(status.state, "idle");
-  assert.equal(status.labelKey, "conversationView.colleagues.runtimeStates.idle");
+  assert.equal(
+    status.labelKey,
+    "conversationView.colleagues.runtimeStates.idle",
+  );
   assert.equal(status.rawRuntimeStatus, "idle");
   assert.equal(status.hasActiveExecution, false);
 });

--- a/frontend/features/servers/lib/agent-runtime-status.test.ts
+++ b/frontend/features/servers/lib/agent-runtime-status.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getAgentRuntimeStatus } from "./agent-runtime-status.ts";
+import type { ServerAgentItem } from "../model/types.ts";
+
+function createAgent(overrides: Partial<ServerAgentItem> = {}): ServerAgentItem {
+  return {
+    id: "agent-1",
+    serverId: "server-1",
+    presetId: 1,
+    handle: "reviewer",
+    displayName: "Reviewer",
+    description: null,
+    visualKey: "preset-visual-1",
+    visibility: "server",
+    lifecycleState: "active",
+    createdBy: "user-1",
+    updatedBy: "user-1",
+    removedAt: null,
+    removedBy: null,
+    persistentState: {
+      id: "state-1",
+      stateRootPath: "agents/agent-1",
+      profilePath: "agents/agent-1/profile.json",
+      memoryPath: "agents/agent-1/MEMORY.md",
+      notesDirPath: "agents/agent-1/notes",
+      stateDirPath: "agents/agent-1/state",
+      artifactsDirPath: "agents/agent-1/artifacts",
+      stateVersion: 1,
+      runtimeStatus: "idle",
+      activeTaskId: null,
+      activeSessionId: null,
+      lastSyncedAt: "2026-05-17T00:00:00.000Z",
+      lastWrittenAt: "2026-05-17T00:00:00.000Z",
+    },
+    createdAt: "2026-05-17T00:00:00.000Z",
+    updatedAt: "2026-05-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("maps idle runtime to the shared idle presentation", () => {
+  const status = getAgentRuntimeStatus(createAgent());
+
+  assert.equal(status.state, "idle");
+  assert.equal(status.labelKey, "conversationView.colleagues.runtimeStates.idle");
+  assert.equal(status.rawRuntimeStatus, "idle");
+  assert.equal(status.hasActiveExecution, false);
+});
+
+test("treats active session/task markers as active even when raw runtime says idle", () => {
+  const status = getAgentRuntimeStatus(
+    createAgent({
+      persistentState: {
+        ...createAgent().persistentState!,
+        runtimeStatus: "idle",
+        activeSessionId: "session-1",
+      },
+    }),
+  );
+
+  assert.equal(status.state, "active");
+  assert.equal(
+    status.labelKey,
+    "conversationView.colleagues.runtimeStates.active",
+  );
+  assert.equal(status.hasActiveExecution, true);
+});
+
+test("prefers removed state over runtime markers", () => {
+  const status = getAgentRuntimeStatus(
+    createAgent({
+      removedAt: "2026-05-17T00:00:00.000Z",
+      persistentState: {
+        ...createAgent().persistentState!,
+        runtimeStatus: "busy",
+        activeSessionId: "session-1",
+      },
+    }),
+  );
+
+  assert.equal(status.state, "removed");
+  assert.equal(
+    status.labelKey,
+    "conversationView.colleagues.runtimeStates.removed",
+  );
+});

--- a/frontend/features/servers/lib/agent-runtime-status.ts
+++ b/frontend/features/servers/lib/agent-runtime-status.ts
@@ -1,8 +1,16 @@
 import type { ServerAgentItem } from "@/features/servers/model/types";
 
 export type AgentRuntimeTone = "success" | "warning" | "danger" | "muted";
+export type AgentRuntimeState =
+  | "active"
+  | "idle"
+  | "stopped"
+  | "removed"
+  | "failed"
+  | "unknown";
 
 export function getAgentRuntimeStatus(agent: ServerAgentItem): {
+  state: AgentRuntimeState;
   labelKey:
     | "conversationView.colleagues.runtimeStates.active"
     | "conversationView.colleagues.runtimeStates.idle"
@@ -11,54 +19,80 @@ export function getAgentRuntimeStatus(agent: ServerAgentItem): {
     | "conversationView.colleagues.runtimeStates.failed"
     | "conversationView.colleagues.runtimeStates.unknown";
   tone: AgentRuntimeTone;
+  rawRuntimeStatus: string | null;
+  rawLifecycleState: string | null;
+  hasActiveExecution: boolean;
 } {
   const lifecycleState = (agent.lifecycleState || "").trim().toLowerCase();
   const runtimeStatus = (agent.persistentState?.runtimeStatus || "")
     .trim()
     .toLowerCase();
+  const hasActiveExecution = Boolean(
+    agent.persistentState?.activeSessionId || agent.persistentState?.activeTaskId,
+  );
 
   if (agent.removedAt) {
     return {
+      state: "removed",
       labelKey: "conversationView.colleagues.runtimeStates.removed",
       tone: "muted",
+      rawRuntimeStatus: runtimeStatus || null,
+      rawLifecycleState: lifecycleState || null,
+      hasActiveExecution,
     };
   }
 
   if (lifecycleState === "inactive") {
     return {
+      state: "stopped",
       labelKey: "conversationView.colleagues.runtimeStates.stopped",
       tone: "muted",
+      rawRuntimeStatus: runtimeStatus || null,
+      rawLifecycleState: lifecycleState || null,
+      hasActiveExecution,
     };
   }
 
-  if (
-    runtimeStatus === "busy" ||
-    agent.persistentState?.activeSessionId ||
-    agent.persistentState?.activeTaskId
-  ) {
+  if (runtimeStatus === "busy" || hasActiveExecution) {
     return {
+      state: "active",
       labelKey: "conversationView.colleagues.runtimeStates.active",
       tone: "warning",
+      rawRuntimeStatus: runtimeStatus || null,
+      rawLifecycleState: lifecycleState || null,
+      hasActiveExecution,
     };
   }
 
   if (runtimeStatus === "failed") {
     return {
+      state: "failed",
       labelKey: "conversationView.colleagues.runtimeStates.failed",
       tone: "danger",
+      rawRuntimeStatus: runtimeStatus || null,
+      rawLifecycleState: lifecycleState || null,
+      hasActiveExecution,
     };
   }
 
   if (runtimeStatus === "idle" || runtimeStatus === "active") {
     return {
+      state: "idle",
       labelKey: "conversationView.colleagues.runtimeStates.idle",
       tone: "success",
+      rawRuntimeStatus: runtimeStatus || null,
+      rawLifecycleState: lifecycleState || null,
+      hasActiveExecution,
     };
   }
 
   return {
+    state: "unknown",
     labelKey: "conversationView.colleagues.runtimeStates.unknown",
     tone: "muted",
+    rawRuntimeStatus: runtimeStatus || null,
+    rawLifecycleState: lifecycleState || null,
+    hasActiveExecution,
   };
 }
 

--- a/frontend/features/servers/lib/agent-runtime-status.ts
+++ b/frontend/features/servers/lib/agent-runtime-status.ts
@@ -28,7 +28,8 @@ export function getAgentRuntimeStatus(agent: ServerAgentItem): {
     .trim()
     .toLowerCase();
   const hasActiveExecution = Boolean(
-    agent.persistentState?.activeSessionId || agent.persistentState?.activeTaskId,
+    agent.persistentState?.activeSessionId ||
+    agent.persistentState?.activeTaskId,
   );
 
   if (agent.removedAt) {

--- a/frontend/features/servers/ui/channel-tasks-workspace.tsx
+++ b/frontend/features/servers/ui/channel-tasks-workspace.tsx
@@ -453,14 +453,18 @@ export function ChannelTasksWorkspace({
       assigneeAgentIdentityId: string | null;
     },
   ) => Promise<void>;
-  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
+  onUpdateStatus: (
+    task: ChannelTask,
+    status: ChannelTaskStatus,
+  ) => Promise<void>;
 }) {
   const { t } = useT("translation");
   const [savingTaskId, setSavingTaskId] = React.useState<string | null>(null);
-  const [draggingTaskId, setDraggingTaskId] = React.useState<string | null>(null);
-  const [hoveredStatus, setHoveredStatus] = React.useState<ChannelTaskStatus | null>(
+  const [draggingTaskId, setDraggingTaskId] = React.useState<string | null>(
     null,
   );
+  const [hoveredStatus, setHoveredStatus] =
+    React.useState<ChannelTaskStatus | null>(null);
 
   const updateAssignee = async (
     task: ChannelTask,
@@ -478,7 +482,10 @@ export function ChannelTasksWorkspace({
   };
 
   const columns = React.useMemo(() => buildChannelTaskColumns(tasks), [tasks]);
-  const listGroups = React.useMemo(() => buildChannelTaskListGroups(tasks), [tasks]);
+  const listGroups = React.useMemo(
+    () => buildChannelTaskListGroups(tasks),
+    [tasks],
+  );
 
   const updateDraggedTaskStatus = async (
     taskId: string,
@@ -616,7 +623,9 @@ export function ChannelTasksWorkspace({
                         {draggingTaskId && hoveredStatus === column.status
                           ? t("channelTasks.dropzone")
                           : t("conversationView.emptyTaskColumn", {
-                              status: t(`channelTasks.statuses.${column.status}`),
+                              status: t(
+                                `channelTasks.statuses.${column.status}`,
+                              ),
                             })}
                       </div>
                     )}

--- a/frontend/features/servers/ui/channel-tasks-workspace.tsx
+++ b/frontend/features/servers/ui/channel-tasks-workspace.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import {
   CornerDownRight,
+  GripVertical,
   LayoutGrid,
   LayoutList,
   UserRound,
@@ -109,13 +110,6 @@ function taskAssigneeValue(task: ChannelTask): string {
   }
   return "none:";
 }
-
-const TASK_STATUS_OPTIONS: ChannelTaskStatus[] = [
-  "todo",
-  "in_progress",
-  "in_review",
-  "done",
-];
 
 type AssigneeOption = {
   value: string;
@@ -336,41 +330,6 @@ function TaskAssignmentControl({
   );
 }
 
-function TaskStatusControl({
-  task,
-  disabled,
-  canUpdateStatus,
-  onUpdateStatus,
-}: {
-  task: ChannelTask;
-  disabled: boolean;
-  canUpdateStatus: boolean;
-  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
-}) {
-  const { t } = useT("translation");
-
-  return (
-    <div onClick={(event) => event.stopPropagation()}>
-      <Select
-        value={task.status}
-        onValueChange={(value) => void onUpdateStatus(task, value as ChannelTaskStatus)}
-        disabled={disabled || !canUpdateStatus}
-      >
-        <SelectTrigger className="h-7 w-auto min-w-[8rem] border-border bg-background text-xs">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {TASK_STATUS_OPTIONS.map((status) => (
-            <SelectItem key={status} value={status}>
-              {t(`channelTasks.statuses.${status}`)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
 function TaskCard({
   task,
   members,
@@ -379,9 +338,11 @@ function TaskCard({
   isSaving,
   canUpdateAssignee,
   canUpdateStatus,
+  isDragging,
   onOpenTask,
+  onDragStart,
+  onDragEnd,
   onUpdateAssignee,
-  onUpdateStatus,
 }: {
   task: ChannelTask;
   members: ServerChannelMemberItem[];
@@ -390,7 +351,10 @@ function TaskCard({
   isSaving: boolean;
   canUpdateAssignee: boolean;
   canUpdateStatus: boolean;
+  isDragging: boolean;
   onOpenTask: (taskId: string) => void;
+  onDragStart: (taskId: string) => void;
+  onDragEnd: () => void;
   onUpdateAssignee: (
     task: ChannelTask,
     value: {
@@ -398,7 +362,6 @@ function TaskCard({
       assigneeAgentIdentityId: string | null;
     },
   ) => Promise<void>;
-  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
 }) {
   const title = normalizeTaskText(task.title);
   const description = normalizeTaskText(task.description);
@@ -406,8 +369,11 @@ function TaskCard({
 
   return (
     <div
+      draggable={canUpdateStatus && !isSaving}
       role="button"
       tabIndex={0}
+      onDragStart={() => onDragStart(task.taskId)}
+      onDragEnd={onDragEnd}
       onClick={() => onOpenTask(task.taskId)}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
@@ -415,20 +381,21 @@ function TaskCard({
           onOpenTask(task.taskId);
         }
       }}
-      className="w-full rounded-md border border-border bg-card px-4 py-4 text-left transition-colors hover:bg-muted/20"
+      className={cn(
+        "group relative w-full rounded-md border border-border bg-card px-4 py-4 text-left transition-colors hover:bg-muted/20",
+        canUpdateStatus ? "cursor-grab active:cursor-grabbing" : "",
+        isDragging ? "opacity-45" : "",
+      )}
     >
-      <div className="flex min-w-0 items-start justify-between gap-3">
-        <div className="min-w-0 space-y-2">
-          <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
-            #{task.displayNumber}
-          </p>
-          <TaskStatusControl
-            task={task}
-            disabled={isSaving}
-            canUpdateStatus={canUpdateStatus}
-            onUpdateStatus={onUpdateStatus}
-          />
+      {canUpdateStatus ? (
+        <div className="pointer-events-none absolute left-1/2 top-1 -translate-x-1/2  px-2 py-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+          <GripVertical className="size-3.5 rotate-90 text-muted-foreground" />
         </div>
+      ) : null}
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+          #{task.displayNumber}
+        </p>
         <TaskAssignmentControl
           task={task}
           members={members}
@@ -490,6 +457,10 @@ export function ChannelTasksWorkspace({
 }) {
   const { t } = useT("translation");
   const [savingTaskId, setSavingTaskId] = React.useState<string | null>(null);
+  const [draggingTaskId, setDraggingTaskId] = React.useState<string | null>(null);
+  const [hoveredStatus, setHoveredStatus] = React.useState<ChannelTaskStatus | null>(
+    null,
+  );
 
   const updateAssignee = async (
     task: ChannelTask,
@@ -504,6 +475,28 @@ export function ChannelTasksWorkspace({
     } finally {
       setSavingTaskId(null);
     }
+  };
+
+  const columns = React.useMemo(() => buildChannelTaskColumns(tasks), [tasks]);
+  const listGroups = React.useMemo(() => buildChannelTaskListGroups(tasks), [tasks]);
+
+  const updateDraggedTaskStatus = async (
+    taskId: string,
+    status: ChannelTaskStatus,
+  ) => {
+    const task = tasks.find((item) => item.taskId === taskId);
+    if (!task || task.status === status) {
+      setDraggingTaskId(null);
+      setHoveredStatus(null);
+      return;
+    }
+
+    setDraggingTaskId(null);
+    setHoveredStatus(null);
+
+    try {
+      await onUpdateStatus(task, status);
+    } catch {}
   };
 
   return (
@@ -550,10 +543,36 @@ export function ChannelTasksWorkspace({
         {taskView === "board" ? (
           <div className="overflow-x-auto">
             <div className="grid min-w-[980px] grid-cols-4 gap-4">
-              {buildChannelTaskColumns(tasks).map((column) => (
+              {columns.map((column) => (
                 <section
                   key={column.status}
-                  className="flex min-h-[32rem] flex-col rounded-md border border-border bg-muted/10 p-3"
+                  onDragOver={(event) => {
+                    if (!draggingTaskId || !canUpdateStatus) {
+                      return;
+                    }
+                    event.preventDefault();
+                    if (hoveredStatus !== column.status) {
+                      setHoveredStatus(column.status);
+                    }
+                  }}
+                  onDragLeave={() => {
+                    if (hoveredStatus === column.status) {
+                      setHoveredStatus(null);
+                    }
+                  }}
+                  onDrop={(event) => {
+                    if (!draggingTaskId || !canUpdateStatus) {
+                      return;
+                    }
+                    event.preventDefault();
+                    void updateDraggedTaskStatus(draggingTaskId, column.status);
+                  }}
+                  className={cn(
+                    "flex min-h-[32rem] flex-col rounded-md border border-border bg-muted/10 p-3 transition-colors",
+                    draggingTaskId && hoveredStatus === column.status
+                      ? "border-primary/60 bg-primary/10"
+                      : "",
+                  )}
                 >
                   <div className="mb-3 flex items-center justify-between gap-3 px-1">
                     <span className="text-sm font-semibold text-foreground">
@@ -575,16 +594,30 @@ export function ChannelTasksWorkspace({
                           isSaving={savingTaskId === task.taskId}
                           canUpdateAssignee={canUpdateAssignee}
                           canUpdateStatus={canUpdateStatus}
+                          isDragging={draggingTaskId === task.taskId}
                           onOpenTask={onOpenTask}
+                          onDragStart={setDraggingTaskId}
+                          onDragEnd={() => {
+                            setDraggingTaskId(null);
+                            setHoveredStatus(null);
+                          }}
                           onUpdateAssignee={updateAssignee}
-                          onUpdateStatus={onUpdateStatus}
                         />
                       ))
                     ) : (
-                      <div className="flex min-h-32 items-center rounded-md border border-dashed border-border bg-background/70 px-4 py-10 text-sm text-muted-foreground">
-                        {t("conversationView.emptyTaskColumn", {
-                          status: t(`channelTasks.statuses.${column.status}`),
-                        })}
+                      <div
+                        className={cn(
+                          "flex min-h-32 items-center rounded-md border border-dashed border-border bg-background/70 px-4 py-10 text-sm text-muted-foreground transition-colors",
+                          draggingTaskId && hoveredStatus === column.status
+                            ? "border-primary/60 bg-primary/10 text-foreground"
+                            : "",
+                        )}
+                      >
+                        {draggingTaskId && hoveredStatus === column.status
+                          ? t("channelTasks.dropzone")
+                          : t("conversationView.emptyTaskColumn", {
+                              status: t(`channelTasks.statuses.${column.status}`),
+                            })}
                       </div>
                     )}
                   </div>
@@ -592,9 +625,9 @@ export function ChannelTasksWorkspace({
               ))}
             </div>
           </div>
-        ) : buildChannelTaskListGroups(tasks).length > 0 ? (
+        ) : listGroups.length > 0 ? (
           <div className="space-y-6">
-            {buildChannelTaskListGroups(tasks).map((group) => (
+            {listGroups.map((group) => (
               <section key={group.status} className="space-y-3">
                 <div className="flex items-center gap-3">
                   <span className="rounded-sm bg-primary/15 px-2 py-1 text-xs font-semibold uppercase text-foreground">
@@ -614,10 +647,12 @@ export function ChannelTasksWorkspace({
                       presets={presets}
                       isSaving={savingTaskId === task.taskId}
                       canUpdateAssignee={canUpdateAssignee}
-                      canUpdateStatus={canUpdateStatus}
+                      canUpdateStatus={false}
+                      isDragging={false}
                       onOpenTask={onOpenTask}
+                      onDragStart={() => {}}
+                      onDragEnd={() => {}}
                       onUpdateAssignee={updateAssignee}
-                      onUpdateStatus={onUpdateStatus}
                     />
                   ))}
                 </div>

--- a/frontend/features/servers/ui/channel-tasks-workspace.tsx
+++ b/frontend/features/servers/ui/channel-tasks-workspace.tsx
@@ -34,6 +34,7 @@ import {
 import type {
   ChannelTaskActorSummary,
   ChannelTask,
+  ChannelTaskStatus,
   ChannelTaskView,
 } from "@/features/channel-tasks/model/types";
 import type {
@@ -108,6 +109,13 @@ function taskAssigneeValue(task: ChannelTask): string {
   }
   return "none:";
 }
+
+const TASK_STATUS_OPTIONS: ChannelTaskStatus[] = [
+  "todo",
+  "in_progress",
+  "in_review",
+  "done",
+];
 
 type AssigneeOption = {
   value: string;
@@ -328,6 +336,41 @@ function TaskAssignmentControl({
   );
 }
 
+function TaskStatusControl({
+  task,
+  disabled,
+  canUpdateStatus,
+  onUpdateStatus,
+}: {
+  task: ChannelTask;
+  disabled: boolean;
+  canUpdateStatus: boolean;
+  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
+}) {
+  const { t } = useT("translation");
+
+  return (
+    <div onClick={(event) => event.stopPropagation()}>
+      <Select
+        value={task.status}
+        onValueChange={(value) => void onUpdateStatus(task, value as ChannelTaskStatus)}
+        disabled={disabled || !canUpdateStatus}
+      >
+        <SelectTrigger className="h-7 w-auto min-w-[8rem] border-border bg-background text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {TASK_STATUS_OPTIONS.map((status) => (
+            <SelectItem key={status} value={status}>
+              {t(`channelTasks.statuses.${status}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 function TaskCard({
   task,
   members,
@@ -335,8 +378,10 @@ function TaskCard({
   presets,
   isSaving,
   canUpdateAssignee,
+  canUpdateStatus,
   onOpenTask,
   onUpdateAssignee,
+  onUpdateStatus,
 }: {
   task: ChannelTask;
   members: ServerChannelMemberItem[];
@@ -344,6 +389,7 @@ function TaskCard({
   presets: Preset[];
   isSaving: boolean;
   canUpdateAssignee: boolean;
+  canUpdateStatus: boolean;
   onOpenTask: (taskId: string) => void;
   onUpdateAssignee: (
     task: ChannelTask,
@@ -352,6 +398,7 @@ function TaskCard({
       assigneeAgentIdentityId: string | null;
     },
   ) => Promise<void>;
+  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
 }) {
   const title = normalizeTaskText(task.title);
   const description = normalizeTaskText(task.description);
@@ -371,9 +418,17 @@ function TaskCard({
       className="w-full rounded-md border border-border bg-card px-4 py-4 text-left transition-colors hover:bg-muted/20"
     >
       <div className="flex min-w-0 items-start justify-between gap-3">
-        <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
-          #{task.displayNumber}
-        </p>
+        <div className="min-w-0 space-y-2">
+          <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+            #{task.displayNumber}
+          </p>
+          <TaskStatusControl
+            task={task}
+            disabled={isSaving}
+            canUpdateStatus={canUpdateStatus}
+            onUpdateStatus={onUpdateStatus}
+          />
+        </div>
         <TaskAssignmentControl
           task={task}
           members={members}
@@ -405,10 +460,12 @@ export function ChannelTasksWorkspace({
   agents,
   presets,
   canUpdateAssignee,
+  canUpdateStatus,
   onSelectChannel,
   onUpdateView,
   onOpenTask,
   onUpdateAssignee,
+  onUpdateStatus,
 }: {
   tasks: ChannelTask[];
   taskView: ChannelTaskView;
@@ -418,6 +475,7 @@ export function ChannelTasksWorkspace({
   agents: ServerAgentItem[];
   presets: Preset[];
   canUpdateAssignee: boolean;
+  canUpdateStatus: boolean;
   onSelectChannel: (channelId: string) => void;
   onUpdateView: (view: ChannelTaskView) => void;
   onOpenTask: (taskId: string) => void;
@@ -428,6 +486,7 @@ export function ChannelTasksWorkspace({
       assigneeAgentIdentityId: string | null;
     },
   ) => Promise<void>;
+  onUpdateStatus: (task: ChannelTask, status: ChannelTaskStatus) => Promise<void>;
 }) {
   const { t } = useT("translation");
   const [savingTaskId, setSavingTaskId] = React.useState<string | null>(null);
@@ -515,8 +574,10 @@ export function ChannelTasksWorkspace({
                           presets={presets}
                           isSaving={savingTaskId === task.taskId}
                           canUpdateAssignee={canUpdateAssignee}
+                          canUpdateStatus={canUpdateStatus}
                           onOpenTask={onOpenTask}
                           onUpdateAssignee={updateAssignee}
+                          onUpdateStatus={onUpdateStatus}
                         />
                       ))
                     ) : (
@@ -553,8 +614,10 @@ export function ChannelTasksWorkspace({
                       presets={presets}
                       isSaving={savingTaskId === task.taskId}
                       canUpdateAssignee={canUpdateAssignee}
+                      canUpdateStatus={canUpdateStatus}
                       onOpenTask={onOpenTask}
                       onUpdateAssignee={updateAssignee}
+                      onUpdateStatus={onUpdateStatus}
                     />
                   ))}
                 </div>

--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -428,7 +428,9 @@ export function AgentDrawer({
             </div>
             <div className="flex flex-wrap gap-2">
               {selectedRuntimeStatus ? (
-                <Badge variant="secondary">{t(selectedRuntimeStatus.labelKey)}</Badge>
+                <Badge variant="secondary">
+                  {t(selectedRuntimeStatus.labelKey)}
+                </Badge>
               ) : null}
               <Badge variant="outline">
                 {selectedRuntimeStatus?.rawRuntimeStatus ??

--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -427,8 +427,11 @@ export function AgentDrawer({
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Badge variant="secondary">
-                {selectedAgent.persistentState?.runtimeStatus ??
+              {selectedRuntimeStatus ? (
+                <Badge variant="secondary">{t(selectedRuntimeStatus.labelKey)}</Badge>
+              ) : null}
+              <Badge variant="outline">
+                {selectedRuntimeStatus?.rawRuntimeStatus ??
                   t("servers.agents.unknown")}
               </Badge>
               <Badge variant="outline">@{selectedAgent.handle}</Badge>

--- a/frontend/features/servers/ui/server-agent-detail-dialog.tsx
+++ b/frontend/features/servers/ui/server-agent-detail-dialog.tsx
@@ -81,7 +81,10 @@ export function ServerAgentDetailDialog({
             <div className="flex flex-wrap gap-2">
               <Badge variant="secondary">{agent.lifecycleState}</Badge>
               <Badge variant="outline">{agent.visibility}</Badge>
-              <Badge variant="outline" className="inline-flex items-center gap-2">
+              <Badge
+                variant="outline"
+                className="inline-flex items-center gap-2"
+              >
                 <span
                   className={cn(
                     "size-2 rounded-full",
@@ -105,7 +108,8 @@ export function ServerAgentDetailDialog({
                   {t(runtimeStatus.labelKey)}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {runtimeStatus.rawRuntimeStatus ?? t("servers.agents.unknown")}
+                  {runtimeStatus.rawRuntimeStatus ??
+                    t("servers.agents.unknown")}
                 </p>
               </div>
               <div className="rounded-2xl border border-border/60 bg-background/80 p-4">

--- a/frontend/features/servers/ui/server-agent-detail-dialog.tsx
+++ b/frontend/features/servers/ui/server-agent-detail-dialog.tsx
@@ -19,8 +19,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  getAgentRuntimeDotClassName,
+  getAgentRuntimeStatus,
+} from "@/features/servers/lib/agent-runtime-status";
 import type { ServerAgentItem } from "@/features/servers/model/types";
 import { useT } from "@/lib/i18n/client";
+import { cn } from "@/lib/utils";
 
 function formatDateTime(value: string | null | undefined): string | null {
   if (!value) {
@@ -49,6 +54,7 @@ export function ServerAgentDetailDialog({
   if (!agent) {
     return null;
   }
+  const runtimeStatus = getAgentRuntimeStatus(agent);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -75,6 +81,15 @@ export function ServerAgentDetailDialog({
             <div className="flex flex-wrap gap-2">
               <Badge variant="secondary">{agent.lifecycleState}</Badge>
               <Badge variant="outline">{agent.visibility}</Badge>
+              <Badge variant="outline" className="inline-flex items-center gap-2">
+                <span
+                  className={cn(
+                    "size-2 rounded-full",
+                    getAgentRuntimeDotClassName(runtimeStatus.tone),
+                  )}
+                />
+                {t(runtimeStatus.labelKey)}
+              </Badge>
               <Badge variant="outline">
                 {t("servers.agents.preset", { id: agent.presetId })}
               </Badge>
@@ -87,8 +102,10 @@ export function ServerAgentDetailDialog({
                   <span>{t("servers.agents.runtimeStatus")}</span>
                 </div>
                 <p className="mt-2 text-sm font-semibold text-foreground">
-                  {agent.persistentState?.runtimeStatus ??
-                    t("servers.agents.unknown")}
+                  {t(runtimeStatus.labelKey)}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {runtimeStatus.rawRuntimeStatus ?? t("servers.agents.unknown")}
                 </p>
               </div>
               <div className="rounded-2xl border border-border/60 bg-background/80 p-4">
@@ -163,6 +180,16 @@ export function ServerAgentDetailDialog({
                 </div>
                 <p className="mt-2 break-all text-foreground">
                   {agent.persistentState?.activeTaskId ??
+                    t("servers.agents.emptyValue")}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-background/80 p-4">
+                <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                  <Container className="size-3.5" />
+                  <span>{t("servers.agents.activeSession")}</span>
+                </div>
+                <p className="mt-2 break-all text-foreground">
+                  {agent.persistentState?.activeSessionId ??
                     t("servers.agents.emptyValue")}
                 </p>
               </div>

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -49,6 +49,7 @@ import { channelTasksApi } from "@/features/channel-tasks/api/channel-tasks-api"
 import { resolveChannelTaskView } from "@/features/channel-tasks/lib/channel-task-board";
 import type {
   ChannelTask,
+  ChannelTaskStatus,
   ChannelTaskView,
 } from "@/features/channel-tasks/model/types";
 import type { Preset } from "@/features/capabilities/presets/lib/preset-types";
@@ -2537,6 +2538,46 @@ export function ServerConversationPageClient({
     }
   };
 
+  const updateTaskStatus = async (
+    task: ChannelTask,
+    status: ChannelTaskStatus,
+  ) => {
+    try {
+      const nextTask = await channelTasksApi.updateTaskStatus(
+        selectedServerId ?? task.serverId,
+        task.channelId,
+        task.taskId,
+        {
+          status,
+          position: task.position,
+        },
+      );
+      setTasks((current) =>
+        current.map((item) =>
+          item.taskId === nextTask.taskId ? nextTask : item,
+        ),
+      );
+      if (
+        drawer.type === "thread" &&
+        nextTask.threadRootMessageId &&
+        drawer.rootMessageId === nextTask.threadRootMessageId
+      ) {
+        setThreadMessages(
+          await serversApi.getThread(
+            selectedServerId ?? nextTask.serverId,
+            nextTask.channelId,
+            nextTask.threadRootMessageId,
+          ),
+        );
+      }
+      toast.success(t("channelTasks.toasts.statusUpdated"));
+    } catch (error) {
+      console.error("[ServersWorkspace] task status update failed", error);
+      toast.error(t("channelTasks.toasts.statusFailed"));
+      throw error;
+    }
+  };
+
   const handleOpenDm = async (agentId: string) => {
     if (!selectedServerId) {
       return;
@@ -3049,7 +3090,7 @@ export function ServerConversationPageClient({
     topLevelChannels,
     directMessages,
     activeChannelId,
-    onSelectServer: setSelectedServerId,
+    onSelectServer: switchServer,
     onOpenServerAccess: () => setServerAccessOpen(true),
     onOpenMode: openMode,
     onOpenTasks: openTaskMode,
@@ -3224,6 +3265,7 @@ export function ServerConversationPageClient({
                 agents={channelAgents}
                 presets={presets}
                 canUpdateAssignee={canManageServerOps}
+                canUpdateStatus={canManageServerOps}
                 onSelectChannel={(value) => {
                   router.push(
                     `/${lng}/servers/${selectedServerId}/channels/${value}?tab=chat&mode=tasks&view=${taskView}`,
@@ -3232,6 +3274,7 @@ export function ServerConversationPageClient({
                 onUpdateView={updateTaskView}
                 onOpenTask={openTaskThread}
                 onUpdateAssignee={updateTaskAssignee}
+                onUpdateStatus={updateTaskStatus}
               />
             ) : (
               <ConversationContent

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -1731,14 +1731,14 @@ export function ServerConversationPageClient({
     if (drawer.type === "colleague" && drawer.selection) {
       return drawer.selection;
     }
-    if (serverAgents[0]) {
-      return { kind: "agent", id: serverAgents[0].id };
+    if (knownAgents[0]) {
+      return { kind: "agent", id: knownAgents[0].id };
     }
     if (serverMembers[0]) {
       return { kind: "human", id: serverMembers[0].id };
     }
     return null;
-  }, [drawer, serverAgents, serverMembers]);
+  }, [drawer, knownAgents, serverMembers]);
   const availableChannelAgents = React.useMemo(() => {
     const existingIds = new Set(channelAgents.map((agent) => agent.id));
     return serverAgents.filter((agent) => !existingIds.has(agent.id));
@@ -3240,7 +3240,7 @@ export function ServerConversationPageClient({
               </section>
             ) : colleaguesModeActive ? (
               <ColleaguesPanel
-                agents={serverAgents}
+                agents={knownAgents}
                 presets={presets}
                 members={serverMembers}
                 selection={colleagueSelection}

--- a/frontend/lib/i18n/locales/de/translation.json
+++ b/frontend/lib/i18n/locales/de/translation.json
@@ -84,6 +84,7 @@
       "stateRoot": "State root",
       "memoryFile": "Memory file",
       "activeTask": "Active task",
+      "activeSession": "Active session",
       "preset": "Preset #{{id}}",
       "tempRuntime": "Temporary runtime",
       "promote": "Promote result",

--- a/frontend/lib/i18n/locales/de/translation.json
+++ b/frontend/lib/i18n/locales/de/translation.json
@@ -2253,7 +2253,15 @@
         "updated": "Vorlage aktualisiert",
         "deleted": "Vorlage gelöscht",
         "saveFailed": "Vorlage konnte nicht gespeichert werden",
-        "deleteFailed": "Vorlage konnte nicht gelöscht werden"
+        "deleteFailed": "Vorlage konnte nicht gelöscht werden",
+        "deleteBlocked": "Can't delete this preset yet: {{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} project defaults",
+        "live_agent_identity": "{{count}} live agents",
+        "active_assignment": "{{count}} active assignments",
+        "channel_task_assignee": "{{count}} channel task assignees",
+        "unknown": "{{count}} unknown dependencies"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/en/translation.json
+++ b/frontend/lib/i18n/locales/en/translation.json
@@ -2232,7 +2232,15 @@
         "updated": "Preset updated",
         "deleted": "Preset deleted",
         "saveFailed": "Failed to save preset",
-        "deleteFailed": "Failed to delete preset"
+        "deleteFailed": "Failed to delete preset",
+        "deleteBlocked": "Can't delete this preset yet: {{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} project defaults",
+        "live_agent_identity": "{{count}} live agents",
+        "active_assignment": "{{count}} active assignments",
+        "channel_task_assignee": "{{count}} channel task assignees",
+        "unknown": "{{count}} unknown dependencies"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/en/translation.json
+++ b/frontend/lib/i18n/locales/en/translation.json
@@ -85,6 +85,7 @@
       "stateRoot": "State root",
       "memoryFile": "Memory file",
       "activeTask": "Active task",
+      "activeSession": "Active session",
       "preset": "Preset #{{id}}",
       "tempRuntime": "Temporary runtime",
       "promote": "Promote result",

--- a/frontend/lib/i18n/locales/fr/translation.json
+++ b/frontend/lib/i18n/locales/fr/translation.json
@@ -84,6 +84,7 @@
       "stateRoot": "State root",
       "memoryFile": "Memory file",
       "activeTask": "Active task",
+      "activeSession": "Active session",
       "preset": "Preset #{{id}}",
       "tempRuntime": "Temporary runtime",
       "promote": "Promote result",

--- a/frontend/lib/i18n/locales/fr/translation.json
+++ b/frontend/lib/i18n/locales/fr/translation.json
@@ -2254,7 +2254,15 @@
         "updated": "Préréglage mis à jour",
         "deleted": "Préréglage supprimé",
         "saveFailed": "Échec de l’enregistrement du préréglage",
-        "deleteFailed": "Échec de la suppression du préréglage"
+        "deleteFailed": "Échec de la suppression du préréglage",
+        "deleteBlocked": "Can't delete this preset yet: {{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} project defaults",
+        "live_agent_identity": "{{count}} live agents",
+        "active_assignment": "{{count}} active assignments",
+        "channel_task_assignee": "{{count}} channel task assignees",
+        "unknown": "{{count}} unknown dependencies"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/ja/translation.json
+++ b/frontend/lib/i18n/locales/ja/translation.json
@@ -84,6 +84,7 @@
       "stateRoot": "State root",
       "memoryFile": "Memory file",
       "activeTask": "Active task",
+      "activeSession": "Active session",
       "preset": "Preset #{{id}}",
       "tempRuntime": "Temporary runtime",
       "promote": "Promote result",

--- a/frontend/lib/i18n/locales/ja/translation.json
+++ b/frontend/lib/i18n/locales/ja/translation.json
@@ -2254,7 +2254,15 @@
         "updated": "プリセットを更新しました",
         "deleted": "プリセットを削除しました",
         "saveFailed": "プリセットの保存に失敗しました",
-        "deleteFailed": "プリセットの削除に失敗しました"
+        "deleteFailed": "プリセットの削除に失敗しました",
+        "deleteBlocked": "Can't delete this preset yet: {{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} project defaults",
+        "live_agent_identity": "{{count}} live agents",
+        "active_assignment": "{{count}} active assignments",
+        "channel_task_assignee": "{{count}} channel task assignees",
+        "unknown": "{{count}} unknown dependencies"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/ru/translation.json
+++ b/frontend/lib/i18n/locales/ru/translation.json
@@ -84,6 +84,7 @@
       "stateRoot": "State root",
       "memoryFile": "Memory file",
       "activeTask": "Active task",
+      "activeSession": "Active session",
       "preset": "Preset #{{id}}",
       "tempRuntime": "Temporary runtime",
       "promote": "Promote result",

--- a/frontend/lib/i18n/locales/ru/translation.json
+++ b/frontend/lib/i18n/locales/ru/translation.json
@@ -2254,7 +2254,15 @@
         "updated": "Пресет обновлён",
         "deleted": "Пресет удалён",
         "saveFailed": "Не удалось сохранить пресет",
-        "deleteFailed": "Не удалось удалить пресет"
+        "deleteFailed": "Не удалось удалить пресет",
+        "deleteBlocked": "Can't delete this preset yet: {{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} project defaults",
+        "live_agent_identity": "{{count}} live agents",
+        "active_assignment": "{{count}} active assignments",
+        "channel_task_assignee": "{{count}} channel task assignees",
+        "unknown": "{{count}} unknown dependencies"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/zh/translation.json
+++ b/frontend/lib/i18n/locales/zh/translation.json
@@ -2232,7 +2232,15 @@
         "updated": "预设已更新",
         "deleted": "预设已删除",
         "saveFailed": "保存预设失败",
-        "deleteFailed": "删除预设失败"
+        "deleteFailed": "删除预设失败",
+        "deleteBlocked": "暂时无法删除该预设：{{dependencies}}"
+      },
+      "deleteDependencies": {
+        "project_default": "{{count}} 个项目默认预设",
+        "live_agent_identity": "{{count}} 个存活 agent",
+        "active_assignment": "{{count}} 个活跃 assignment",
+        "channel_task_assignee": "{{count}} 个频道任务分配",
+        "unknown": "{{count}} 个未知依赖"
       }
     },
     "skillSettings": {

--- a/frontend/lib/i18n/locales/zh/translation.json
+++ b/frontend/lib/i18n/locales/zh/translation.json
@@ -85,6 +85,7 @@
       "stateRoot": "状态根目录",
       "memoryFile": "记忆文件",
       "activeTask": "当前任务",
+      "activeSession": "当前会话",
       "preset": "Preset #{{id}}",
       "tempRuntime": "临时 runtime",
       "promote": "提升结果",

--- a/specs/active/29-server-agent-status-consistency-plan.md
+++ b/specs/active/29-server-agent-status-consistency-plan.md
@@ -1,0 +1,528 @@
+# Server agent status consistency plan
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **创建日期** | 2026-05-17 |
+| **预期改动范围** | frontend server workspace / agent runtime status model / backend persistent runtime reconciliation / channel task assignment semantics / preset deletion validation / targeted tests |
+| **改动类型** | fix |
+| **优先级** | P1 |
+| **状态** | draft |
+| **关联 issue** | `poco-ai/poco-claw#114 Display status inconsistency` |
+
+## 实施阶段
+
+- [ ] Phase 0: 固定问题边界与统一状态词典
+- [ ] Phase 1: 收敛 agent runtime 单一状态源
+- [ ] Phase 2: 增加 stale runtime / stale executor 回收机制
+- [ ] Phase 3: 对齐 task 分配、执行与 UI 状态语义
+- [ ] Phase 4: 收敛 inbox、页面导航与 preset 删除反馈
+- [ ] Phase 5: 验证、灰度检查与 spec 回写
+
+---
+
+## 背景
+
+`issue #114` 表面上是“显示状态不一致”，但结合截图、评论和当前代码，实际暴露的是一组跨前后端的状态模型断裂：
+
+- 同一个 agent 在不同 UI 面板中使用不同状态判定逻辑。
+- task 的“分配”“开始执行”“进行中”没有被清晰区分，导致用户看到待开始卡片、系统事件和 agent 详情互相打架。
+- executor / persistent agent 的忙闲状态只依赖 callback 终态释放，一旦 callback 缺失、session 残留或 placeholder 没回收，就会长期卡在 busy。
+- inbox 未读数完全由前端本地 `readMessageIds` 和启发式 `hasInboxSignal()` 计算，缺少稳定的服务端语义。
+- preset 删除失败只有通用 400，没有把“被谁占用、为什么删不了”反馈到 UI。
+
+当前代码已经能解释 issue 中的大部分现象：
+
+- `frontend/features/servers/lib/agent-runtime-status.ts` 用派生逻辑把 `runtime_status + active_session_id + active_task_id` 折叠成前端标签。
+- `frontend/features/servers/ui/server-agent-detail-dialog.tsx` 却直接显示原始 `persistentState.runtimeStatus`，没有复用同一派生结果。
+- `frontend/features/servers/ui/server-workspace-sidebar.tsx` 的 server 下拉仅调用 `setSelectedServerId`，没有复用 `switchServer()` 的 URL 同步路径，容易让旧 `channelId` 和新 server 脱钩。
+- `frontend/features/servers/ui/server-conversation-page-client.tsx` 里的 `activeChannelIdByAgentId` 依赖“当前已加载消息里的 session id -> channel id 映射”，不是稳定后端字段。
+- 当前 route 走的是 `frontend/features/servers/ui/channel-tasks-workspace.tsx`，但旧的 `frontend/features/channel-tasks/ui/channel-task-page-client.tsx` 仍保留另一套 task 状态编辑/拖拽语义，前端实际上有两套 task surface。
+- `backend/app/services/agent_runtime_service.py` 只有在 callback 收到 `completed/failed/canceled` 时才释放 runtime；没有补偿式 reconciliation。
+- `backend/app/services/agent_assignment_service.py` 在切换 preset / trigger mode 时先覆写 assignment 字段，再做比较，旧 `session_id` / `container_id` 的清理分支实际上很容易失效。
+- `backend/app/services/server_channel_task_service.py` 中 `claim_task()` 只更新 assignee，不改变 task status，也不会创建“执行已启动”的单独语义。
+- `backend/app/services/server_channel_task_service.py` 允许 `assignee_preset_id` 进入 claim/update 流程，但 `_validate_task_assignee()` 并不校验 preset 是否仍可见或可用。
+- `backend/app/services/preset_service.py` 的 `delete_preset()` 只校验 project default usage，没有把 server agent / channel agent / assignment 等依赖暴露给前端。
+
+因此这次修复不能只改某一个 badge 文案，而是要把“状态从哪里来、什么时刻迁移、哪些页面消费同一个语义”全部固定下来。
+
+## 目标
+
+本计划要把 server / channel 协作中的几套状态重新收敛成一套可解释、可回收、可复用的模型：
+
+- 为 persistent agent 建立唯一的 runtime summary，并保证同事列表、详情面板、任务面板、执行抽屉消费同一个状态派生结果。
+- 为 stale session / stale executor / callback 丢失场景增加后端 reconciliation，让 busy 状态不会永久残留。
+- 明确区分 task 的 assignment state、workflow status、execution activity，避免“分配后立即显示运行中”的心智混乱。
+- 让 inbox count、搜索/服务器菜单切换和 loading 状态更稳定，不再依赖脆弱的本地推断。
+- 让 preset 删除失败能返回结构化占用原因，而不是单纯 400。
+
+## 非目标
+
+- 不把 channel task 改成自动跟随 executor run 的强绑定对象；task 仍然可以已分配但未开始执行。
+- 不在本轮引入 websocket / SSE；继续基于轮询和现有 API 收敛状态。
+- 不重做整个 server workspace 导航布局。
+- 不处理多 executor_manager 的部署拓扑和本地路径映射策略；这单独作为运维/架构议题记录。
+- 不在本轮删除 `assignee_preset_id` 兼容字段。
+
+## 关键洞察
+
+### 1. “原始 runtime_status” 不是可直接展示给用户的最终状态
+
+后端 `runtime_status` 只是持久状态文件上的一个低层字段；用户真正关心的是：
+
+- 这个 agent 现在是否可接新活
+- 它是不是被残留 session 卡住了
+- 它当前忙是因为活跃执行，还是因为坏状态没有清掉
+
+因此 UI 不应一处显示派生状态、一处显示原始值，而应有统一的 `runtime summary`。
+
+### 2. task 分配和 task 执行是两个不同状态机
+
+`claim_task()` 当前只意味着“谁负责”，不意味着“开始运行”。issue 里“分配就去运行中？”正是因为产品没有把这两个概念拆开。修复方向不应是偷偷让 claim 自动推进到 `in_progress`，而是把 assignment / workflow / execution 三者明确呈现出来。
+
+### 3. stale busy 比“显示错字”更严重，因为它会污染调度和认知
+
+一旦 `active_session_id` 没释放，前端同事列表、详情、回跳 channel、甚至后续 trigger 行为都会被误导。这个问题必须在后端补偿，而不能只在前端忽略掉。
+
+### 4. inbox 不能只靠浏览器本地状态推断
+
+当前 inbox count 完全由 `localStorage` 的 `readMessageIds` 决定，切换菜单、切换设备、进入 server 页面都会出现不一致。短期不一定要做全服务端未读系统，但至少要把当前 feed signal 和 read marking 规则收敛。
+
+---
+
+## Phase 0: 固定问题边界与统一状态词典
+
+### 目标
+
+先把当前实现中的几套“状态”逐一命名，明确每个字段的语义和消费者，避免实现时继续混用。
+
+### 任务清单
+
+#### 0.1 列出当前状态来源与消费者矩阵
+
+**描述：** 以 spec 表格形式整理以下字段和页面：
+
+- `AgentPersistentState.runtime_status`
+- `AgentPersistentState.active_session_id`
+- `AgentPersistentState.active_task_id`
+- channel task `status`
+- task assignee 字段
+- execution placeholder `content.execution_status`
+- inbox `readMessageIds`
+
+**涉及文件：**
+
+- `frontend/features/servers/lib/agent-runtime-status.ts`
+- `frontend/features/servers/ui/server-agent-detail-dialog.tsx`
+- `frontend/features/servers/ui/server-conversation-page-client.tsx`
+- `backend/app/services/agent_runtime_service.py`
+- `backend/app/services/server_channel_task_service.py`
+- `backend/app/repositories/server_channel_message_repository.py`
+
+**验收标准：**
+
+- [ ] 每个状态字段有明确“来源 / 更新时机 / 消费页面 / 是否直接展示”
+- [ ] 明确哪些字段是原始状态，哪些字段是派生状态
+
+#### 0.2 固定前端展示词典
+
+**描述：** 明确用户可见的 agent runtime 标签仅保留以下集合：
+
+- `idle`
+- `busy`
+- `failed`
+- `stopped`
+- `removed`
+- `unknown`
+- `stale`（仅当后端或前端检测到残留执行态时）
+
+**验收标准：**
+
+- [ ] 所有 agent 相关 UI 只显示同一套文案 key
+- [ ] 原始 `runtime_status` 不再直接裸露给最终用户
+
+---
+
+## Phase 1: 收敛 agent runtime 单一状态源
+
+### 目标
+
+让同事列表、agent 详情、回跳 channel、执行抽屉共享同一派生结果，而不是各自推断。
+
+### 任务清单
+
+#### 1.1 引入前端统一 runtime summary mapper
+
+**描述：** 把 `getAgentRuntimeStatus()` 扩展为完整 summary helper，输出：
+
+- normalized status key
+- tone
+- active session id
+- active task id
+- active channel id（若可确定）
+- stale hint（若 runtime 和执行占位信息冲突）
+
+**涉及文件：**
+
+- `frontend/features/servers/lib/agent-runtime-status.ts`
+- `frontend/features/servers/model/types.ts`
+
+**验收标准：**
+
+- [ ] helper 输出结构化 summary，而不是只输出 labelKey/tone
+- [ ] detail dialog 与 colleagues panel 都消费同一 helper
+
+#### 1.2 用统一 summary 改造 agent 详情弹窗
+
+**描述：** `server-agent-detail-dialog.tsx` 不能再直接显示 `persistentState.runtimeStatus`。顶部 badge、详情卡片、active task / active session 信息要同时展示“用户可见状态”和“调试字段”。
+
+**涉及文件：**
+
+- `frontend/features/servers/ui/server-agent-detail-dialog.tsx`
+- `frontend/lib/i18n/locales/*/translation.json`
+
+**验收标准：**
+
+- [ ] 同一个 agent 在列表和详情里的主状态标签一致
+- [ ] 原始 runtime 字段仅作为 secondary debug 信息出现
+
+#### 1.3 稳定 active channel 回跳来源
+
+**描述：** `activeChannelIdByAgentId` 不能只依赖当前内存里的 `sessionId -> channelId` 映射。需要优先消费后端返回的稳定字段；若后端暂时没有，至少补一层 placeholder / recent execution message 回填策略。
+
+**涉及文件：**
+
+- `frontend/features/servers/ui/server-conversation-page-client.tsx`
+- `frontend/features/servers/api/servers-api.ts`
+- `backend/app/schemas/agent_identity.py`
+- `backend/app/services/agent_identity_service.py`
+
+**验收标准：**
+
+- [ ] agent 处于 busy 时，若后台已知 active channel，前端可稳定回跳
+- [ ] 不再因为当前页面没加载某个 channel 的消息而丢失回跳入口
+
+---
+
+## Phase 2: 增加 stale runtime / stale executor 回收机制
+
+### 目标
+
+解决“确认没有任务在执行，但 executor 还显示卡死 / agent 仍是运行中”的残留状态问题。
+
+### 任务清单
+
+#### 2.1 提炼 runtime reconciliation 规则
+
+**描述：** 对 persistent agent 增加后端 reconciliation 逻辑。若 `active_session_id` 指向的 session 已终态、run 不存在、queue item 全部终态，或 placeholder 全部终态，则把 runtime 从 `busy` 释放为 `idle` / `failed`。
+
+**涉及文件：**
+
+- `backend/app/services/agent_runtime_service.py`
+- `backend/app/services/session_service.py`
+- `backend/app/services/callback_service.py`
+- `backend/app/repositories/session_repository.py`
+- `backend/app/repositories/run_repository.py`
+- `backend/app/repositories/session_queue_item_repository.py`
+
+**验收标准：**
+
+- [ ] callback 正常到达时仍走现有快速释放路径
+- [ ] callback 缺失时，reconciliation 也能在后续读请求或轮询中清理残留状态
+
+#### 2.2 在 agent list/get 读取路径上做被动修复
+
+**描述：** `AgentIdentityService.list_agents()` / `get_agent()` 在返回前，对 persistent state 执行一次轻量 reconciliation，避免用户只能通过重启 agent 才恢复状态。
+
+**涉及文件：**
+
+- `backend/app/services/agent_identity_service.py`
+- `backend/app/repositories/agent_identity_repository.py`
+- `backend/tests/test_agent_runtime_service.py`
+- `backend/tests/test_agent_identity_service.py`
+
+**验收标准：**
+
+- [ ] stale busy agent 打开 server 页面即可被纠正
+- [ ] reconciliation 不会错误打断真实运行中的 session
+
+#### 2.3 定义 stale 状态的前端降级展示
+
+**描述：** 如果前端发现 summary 与后端原始字段仍短暂冲突，优先展示 `stale` / “syncing” 风格，而不是一处 active 一处 idle。
+
+**涉及文件：**
+
+- `frontend/features/servers/lib/agent-runtime-status.ts`
+- `frontend/features/servers/ui/colleagues-panel.tsx`
+
+**验收标准：**
+
+- [ ] 冲突窗口期内 UI 以单一状态展示
+- [ ] 用户能理解“正在回收/同步”，而不是看到矛盾结果
+
+#### 2.4 修正 assignment 切 preset / mode 时的旧 session 残留
+
+**描述：** `AgentAssignmentService.sync_issue_assignment()` 需要在更新 `preset_id` / `trigger_mode` 前保留旧值并比较，确保配置切换时能正确清空旧 `session_id`、`container_id`、`last_triggered_at`。
+
+**涉及文件：**
+
+- `backend/app/services/agent_assignment_service.py`
+- `backend/tests/test_agent_assignment_service.py`
+
+**验收标准：**
+
+- [ ] 切换 preset 或 trigger mode 后，不会继续绑定旧 session/container
+- [ ] 旧 assignment runtime 不会以新配置名义继续显示为活跃
+
+---
+
+## Phase 3: 对齐 task 分配、执行与 UI 状态语义
+
+### 目标
+
+把 issue 中“分配就去运行中？”和“待开始卡片 + 执行事件”混乱拆开。
+
+### 任务清单
+
+#### 3.1 固定 task 三层状态模型
+
+**描述：** 文档和 UI 都明确区分：
+
+- **assignee**：谁负责
+- **workflow status**：`todo / in_progress / in_review / done`
+- **execution activity**：是否存在活跃 agent execution placeholder / active session
+
+**涉及文件：**
+
+- `backend/app/services/server_channel_task_service.py`
+- `frontend/features/channel-tasks/model/types.ts`
+- `frontend/features/channel-tasks/ui/channel-task-detail-dialog.tsx`
+- `frontend/features/channel-tasks/ui/channel-task-page-client.tsx`
+
+**验收标准：**
+
+- [ ] claim / unclaim 不自动改 workflow status
+- [ ] 详情面板里能同时看到 assignee 和 execution activity
+
+#### 3.2 为 task 提供 execution summary 或关联 session
+
+**描述：** 若某个 task 当前正由 persistent agent 执行，需要让前端从结构化字段得知“这个 task 对应一个 active session”，而不是从消息流间接猜。
+
+**涉及文件：**
+
+- `backend/app/schemas/server_channel_task.py`
+- `backend/app/services/server_channel_task_service.py`
+- `backend/app/services/server_agent_trigger_service.py`
+- `frontend/features/channel-tasks/api/channel-tasks-api.ts`
+- `frontend/features/channel-tasks/model/types.ts`
+
+**验收标准：**
+
+- [ ] task 卡片或详情可显示“assigned but not running”与“assigned and executing”的区别
+- [ ] 任务面板不再把“已分配”误解为“进行中”
+
+#### 3.3 收敛 task 事件文案
+
+**描述：** task event 文案需要明确是 `assigned`, `unassigned`, `status_changed`, `execution started`, `execution failed`, `execution completed` 中的哪一种，避免用户把 channel event 看成 workflow 列状态。
+
+**涉及文件：**
+
+- `backend/app/services/server_channel_task_service.py`
+- `backend/app/services/callback_service.py`
+- `frontend/features/servers/ui/conversation-message-row.tsx`
+- `frontend/lib/i18n/locales/*/translation.json`
+
+**验收标准：**
+
+- [ ] “分配给 tttt” 不会在视觉上被解释成“任务已经运行”
+- [ ] 运行相关事件只能来自 execution path，不由 claim path 冒充
+
+#### 3.4 补齐 preset assignee 合法性校验
+
+**描述：** 若本轮继续保留 `assignee_preset_id` 兼容路径，就必须显式校验 preset 是否存在、当前用户是否可见、是否允许作为当前 server/channel 的 task assignee；否则应拒绝写入，而不是让 UI 留下“找不到 preset”的悬挂状态。
+
+**涉及文件：**
+
+- `backend/app/services/server_channel_task_service.py`
+- `backend/app/repositories/preset_repository.py`
+- `backend/tests/test_server_channel_task_service.py`
+
+**验收标准：**
+
+- [ ] task claim/update 不能写入软删除或不可见 preset
+- [ ] assignee summary 不再因为非法 preset 引用而退化为残缺展示
+
+---
+
+## Phase 4: 收敛 inbox、页面导航与 preset 删除反馈
+
+### 目标
+
+覆盖 issue 中剩余但仍与“状态一致性”强相关的几个表象问题。
+
+### 任务清单
+
+#### 4.1 重新定义 inbox signal 与 unread count
+
+**描述：** 当前 `hasInboxSignal()` 过于宽松，只要 `replyCount > 0` 就进 inbox，且未读完全依赖本地 `readMessageIds`。本轮要至少做到：
+
+- 统一 server/channel/search/inbox 之间的 read marking 规则
+- 排除当前用户自己发出的普通 user message
+- 为 event / execution placeholder 定义是否进入 inbox 的明确规则
+
+**涉及文件：**
+
+- `frontend/features/servers/lib/server-conversation-view.ts`
+- `frontend/features/servers/ui/server-conversation-page-client.tsx`
+- `frontend/features/servers/ui/conversation-panels.tsx`
+
+**验收标准：**
+
+- [ ] 左侧 inbox count 与 inbox 面板内 unread/all 统计一致
+- [ ] 切换菜单后不会出现明显的 0 / 非 0 矛盾
+
+#### 4.2 修复菜单切换时的错误 loading 态残留
+
+**描述：** 从其他菜单进入 server 页面时，`mode`, `selectedChannel`, `drawer`, `isMobileDetailVisible` 和 thread load 的切换次序要收敛，避免长期显示“正在加载会话”。此外，server 下拉切换必须复用 URL-aware 的 `switchServer()` 路径，不能只改本地 state。
+
+**涉及文件：**
+
+- `frontend/features/servers/ui/server-conversation-page-client.tsx`
+- `frontend/features/servers/ui/conversation-drawers.tsx`
+- `frontend/features/servers/ui/server-workspace-sidebar.tsx`
+
+**验收标准：**
+
+- [ ] 从 search/tasks/colleagues/inbox 切回 server conversation 不会卡在 loading title
+- [ ] drawer 切换不会保留上一状态的 root message
+- [ ] server 下拉切换后不会保留上一个 server 的 `channelId` 路由参数
+
+#### 4.3 收敛 task surface，只保留一套 server route 语义
+
+**描述：** 当前 route 实际使用 `channel-tasks-workspace.tsx`，但旧的 `channel-task-page-client.tsx` 仍保留另一套拖拽和详情逻辑。本轮需要明确哪一套是 canonical surface，并把另一套改为复用或下线，避免未来继续引入双重状态模型。
+
+**涉及文件：**
+
+- `frontend/features/servers/ui/channel-tasks-workspace.tsx`
+- `frontend/features/channel-tasks/ui/channel-task-page-client.tsx`
+- `frontend/features/channel-tasks/index.ts`
+- `frontend/features/servers/ui/server-workspace-types.ts`
+
+**验收标准：**
+
+- [ ] 服务器路由只存在一套 task 状态变更和详情交互语义
+- [ ] 不再出现一套 UI 可以改 status、另一套 UI 只能改 assignee 的分裂行为
+
+#### 4.4 为 preset 删除返回结构化占用原因
+
+**描述：** `delete_preset()` 需要补依赖检查，并把失败原因结构化返回，例如：
+
+- used as project default
+- referenced by live server agent
+- referenced by pending assignment / scheduled task
+
+前端删除提示要能展示“为什么删不了”，而不是只有“删除失败”。
+
+**涉及文件：**
+
+- `backend/app/services/preset_service.py`
+- `backend/app/repositories/preset_repository.py`
+- `backend/app/schemas/preset.py`
+- `backend/tests/test_preset_services.py`
+- `backend/tests/test_agent_assignment_service.py`
+- `frontend/features/capabilities/presets/api/presets-api.ts`
+- `frontend/features/capabilities/presets/components/presets-page-client.tsx`
+
+**验收标准：**
+
+- [ ] 后端返回结构化 dependency reason
+- [ ] 前端 toast / dialog 能说明具体阻塞项
+
+---
+
+## Phase 5: 验证、灰度检查与 spec 回写
+
+### 目标
+
+在不引入 websocket 的前提下，用针对性测试和手动回归保证状态收敛。
+
+### 任务清单
+
+#### 5.1 后端单元测试
+
+**涉及文件：**
+
+- `backend/tests/test_agent_runtime_service.py`
+- `backend/tests/test_agent_identity_service.py`
+- `backend/tests/test_server_channel_task_service.py`
+- `backend/tests/test_preset_services.py`
+
+**验收标准：**
+
+- [ ] busy -> idle/failed/stale reconciliation 有测试
+- [ ] task assignment 与 execution summary 解耦有测试
+- [ ] preset deletion dependency reason 有测试
+
+#### 5.2 前端单元测试
+
+**涉及文件：**
+
+- `frontend/features/servers/lib/agent-runtime-status.test.ts`
+- `frontend/features/servers/lib/server-conversation-view.test.ts`
+- `frontend/features/channel-tasks/lib/*.test.ts`
+
+**验收标准：**
+
+- [ ] 同一输入在列表/详情得到同一主状态
+- [ ] inbox signal / unread count 规则稳定
+- [ ] task assigned vs executing 的渲染规则稳定
+
+#### 5.3 手动回归脚本
+
+**场景：**
+
+1. 创建 server agent，确认列表与详情都显示 idle
+2. 在 channel 中 mention agent，确认状态变为 busy，并可回跳到正确 channel
+3. 人工取消 / 失败 / callback 缺失模拟，确认 stale busy 被自动释放
+4. 创建并分配 task，确认仍停留在 `todo`，但 assignee 已更新
+5. 让 agent 真正执行 task，确认 execution activity 出现且不与 task column 混淆
+6. 切换到 inbox / search / servers 菜单，确认 unread count 与页面内容一致
+7. 删除被占用 preset，确认 UI 给出明确依赖原因
+
+---
+
+## 风险与权衡
+
+- **读取时 reconciliation 会增加少量查询开销。**
+  这是可接受的，因为当前最严重的问题是 stale busy 污染整个协作心智。可以先做轻量判断，再按需下钻 run / queue 状态。
+
+- **task execution summary 若直接从消息流推导，仍会脆弱。**
+  因此本 spec 倾向于在 task response 中返回结构化字段，而不是继续让前端用 event 或 placeholder 猜。
+
+- **inbox 若继续保留完全本地未读模型，多端一致性仍有限。**
+  本轮只要求前端规则内部一致，不把它升级成全服务端未读系统。
+
+## 并行实施建议
+
+为后续 `fix/issue-114-status-consistency` 分支上的并行开发，建议拆成三路：
+
+- **Worker A: backend runtime reconciliation**
+  负责 `agent_runtime_service.py`、`agent_identity_service.py`、callback / session 释放链路及相关测试。
+
+- **Worker B: frontend runtime and inbox consistency**
+  负责 `frontend/features/servers/*` 的 runtime summary、sidebar inbox count、menu/loading 状态与测试。
+
+- **Worker C: task semantics and preset deletion feedback**
+  负责 task execution summary、event 文案、preset dependency 校验与前端错误提示。
+
+三路的写集基本可分离，最后只在 i18n 文案与类型定义上做小规模整合。
+
+## 决策结论
+
+这次 issue 的本质不是单个显示 bug，而是 persistent agent、channel task、execution placeholder、inbox feed 四套状态系统没有共享同一个语义层。修复策略应当是：
+
+1. 先定义统一状态词典；
+2. 再让后端补 runtime 回收；
+3. 然后让前端所有 surface 复用同一个 summary；
+4. 最后把 task / inbox / preset 删除这些边缘症状收束到同一模型里。


### PR DESCRIPTION
## 变更概述

这个 PR 主要针对 `#114 Display status inconsistency` 中暴露出来的几类状态不一致问题进行收敛，重点覆盖 server agent runtime、channel task 交互、preset 删除反馈，以及相关的后端状态回收逻辑。

## 具体修改

- 统一 server workspace 中 agent 状态的展示逻辑
  - 让同事列表、详情面板、drawer 复用同一套 runtime summary
  - 修复左侧同事列表和右侧详情面板因为数据源不同而出现的状态更新不同步

- 收敛 channel task board 的交互
  - 移除手动状态下拉
  - 恢复通过拖拽跨列更新任务状态
  - 增加 hover 拖拽手柄、抓取态 cursor、目标列高亮等可视反馈

- 强化后端 runtime / assignment 一致性
  - 修复切换 preset 或 trigger mode 后旧 session / container 绑定没有被正确清理的问题
  - 增加 persistent runtime reconciliation，缓解 stale busy 残留
  - 避免 terminal callback 到来时过早把仍有后续工作的 runtime 释放为 idle

- 强化 preset 相关约束与反馈
  - 删除 preset 时，若仍被 live agent / active assignment / channel task assignee 引用，则阻止删除
  - 前端将后端返回的 dependency reason 翻译为可读的中文错误提示
  - 校验 task 中 preset assignee 的合法性，避免落入无效引用

## 验证

已执行的验证包括：

- `node --test --experimental-strip-types --experimental-specifier-resolution=node frontend/features/servers/lib/agent-runtime-status.test.ts`
- `cd backend && PYTHONPATH=. uv run python -m unittest tests.test_agent_assignment_service tests.test_agent_runtime_service tests.test_preset_services tests.test_server_channel_task_service`
- `pre-commit run --all-files`

## 备注

这次改动已经覆盖 issue 主线中的状态显示不一致问题，但没有完整重做 inbox/unread 的底层模型，也没有重构 executor pool 的整体占用追踪逻辑。
