### PR TITLE
feat: 频道聊天上传共享文件 && 体验调整

### DIFF
--- a/backend/alembic/versions/ab4f7c9d2e31_allow_channel_upload_artifacts.py
+++ b/backend/alembic/versions/ab4f7c9d2e31_allow_channel_upload_artifacts.py
@@ -1,0 +1,40 @@
+"""allow channel upload artifacts
+
+Revision ID: ab4f7c9d2e31
+Revises: 9dfa9009ffbd
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ab4f7c9d2e31"
+down_revision: Union[str, Sequence[str], None] = "9dfa9009ffbd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        "channel_artifacts",
+        "source_session_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DELETE FROM channel_artifacts WHERE source_session_id IS NULL")
+    op.alter_column(
+        "channel_artifacts",
+        "source_session_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )

--- a/backend/app/api/v1/audio.py
+++ b/backend/app/api/v1/audio.py
@@ -2,13 +2,31 @@ from fastapi import APIRouter, Depends, File, Form, UploadFile
 from fastapi.responses import JSONResponse
 
 from app.core.deps import get_current_user_id
-from app.schemas.audio import AudioTranscriptionResponse
+from app.schemas.audio import (
+    AudioTranscriptionResponse,
+    AudioTranscriptionSupportResponse,
+)
 from app.schemas.response import Response, ResponseSchema
 from app.services.audio_transcription_service import AudioTranscriptionService
 
 router = APIRouter(prefix="/audio", tags=["audio"])
 
 audio_transcription_service = AudioTranscriptionService()
+
+
+@router.get(
+    "/transcriptions/support",
+    response_model=ResponseSchema[AudioTranscriptionSupportResponse],
+)
+async def get_audio_transcription_support(
+    user_id: str = Depends(get_current_user_id),
+) -> JSONResponse:
+    return Response.success(
+        data=AudioTranscriptionSupportResponse(
+            available=audio_transcription_service.is_available(),
+        ),
+        message="Audio transcription support resolved successfully",
+    )
 
 
 @router.post(

--- a/backend/app/api/v1/server_channel_artifacts.py
+++ b/backend/app/api/v1/server_channel_artifacts.py
@@ -1,11 +1,12 @@
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.core.deps import get_current_user, get_db
 from app.models.user import User
+from app.schemas.input_file import InputFile
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.workspace import FileNode
 from app.services.channel_artifact_service import ChannelArtifactService
@@ -34,4 +35,25 @@ async def list_channel_artifacts(
     return Response.success(
         data=result,
         message="Channel artifacts retrieved successfully",
+    )
+
+
+@router.post("/artifacts/upload", response_model=ResponseSchema[InputFile])
+async def upload_channel_artifact(
+    server_id: uuid.UUID,
+    channel_id: uuid.UUID,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    result = service.upload_channel_artifact(
+        db,
+        current_user=current_user,
+        server_id=server_id,
+        channel_id=channel_id,
+        file=file,
+    )
+    return Response.success(
+        data=result,
+        message="Channel artifact uploaded successfully",
     )

--- a/backend/app/models/channel_artifact.py
+++ b/backend/app/models/channel_artifact.py
@@ -38,9 +38,9 @@ class ChannelArtifact(Base, TimestampMixin):
         nullable=False,
         index=True,
     )
-    source_session_id: Mapped[uuid.UUID] = mapped_column(
+    source_session_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("agent_sessions.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     agent_identity_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/app/repositories/channel_artifact_repository.py
+++ b/backend/app/repositories/channel_artifact_repository.py
@@ -31,6 +31,11 @@ class ChannelArtifactRepository:
     ) -> list[ChannelArtifact]:
         persisted: list[ChannelArtifact] = []
         for artifact in artifacts:
+            if artifact.source_session_id is None:
+                session_db.add(artifact)
+                persisted.append(artifact)
+                continue
+
             existing = cls.get_by_session_and_path(
                 session_db,
                 source_session_id=artifact.source_session_id,

--- a/backend/app/schemas/audio.py
+++ b/backend/app/schemas/audio.py
@@ -3,3 +3,7 @@ from pydantic import BaseModel
 
 class AudioTranscriptionResponse(BaseModel):
     text: str
+
+
+class AudioTranscriptionSupportResponse(BaseModel):
+    available: bool

--- a/backend/app/schemas/channel_artifact.py
+++ b/backend/app/schemas/channel_artifact.py
@@ -8,7 +8,7 @@ class ChannelArtifactResponse(BaseModel):
     artifact_id: UUID = Field(validation_alias="id")
     server_id: UUID
     channel_id: UUID
-    source_session_id: UUID
+    source_session_id: UUID | None = None
     agent_identity_id: UUID | None = None
     publisher_user_id: str | None = None
     source_kind: str
@@ -29,7 +29,7 @@ class AgentChannelArtifactMetadata(BaseModel):
     logical_path: str
     display_name: str
     source_kind: str
-    source_session_id: UUID
+    source_session_id: UUID | None = None
     agent_identity_id: UUID | None = None
     publisher_user_id: str | None = None
     mime_type: str | None = None

--- a/backend/app/services/audio_transcription_service.py
+++ b/backend/app/services/audio_transcription_service.py
@@ -48,6 +48,13 @@ class AudioTranscriptionService:
             return f"{normalized}/audio/transcriptions"
         return f"{normalized}/v1/audio/transcriptions"
 
+    def is_available(self) -> bool:
+        return bool(
+            (self.settings.openai_api_key or "").strip()
+            and (self.settings.openai_base_url or "").strip()
+            and self.settings.openai_audio_transcription_model.strip()
+        )
+
     @staticmethod
     def _normalize_language(language: str | None) -> str | None:
         value = (language or "").strip().lower()

--- a/backend/app/services/channel_artifact_service.py
+++ b/backend/app/services/channel_artifact_service.py
@@ -1,9 +1,13 @@
+import os
+import re
 import uuid
 from pathlib import PurePosixPath
 from typing import Any, cast
 
+from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
+from app.core.settings import get_settings
 from app.core.errors.error_codes import ErrorCode
 from app.core.errors.exceptions import AppException
 from app.models.agent_session import AgentSession
@@ -20,6 +24,7 @@ from app.schemas.channel_artifact import (
     AgentChannelArtifactReadResponse,
     AgentChannelArtifactSearchResponse,
 )
+from app.schemas.input_file import InputFile
 from app.schemas.workspace import FileNode
 from app.services.server_channel_access import require_channel_member_access
 from app.services.storage_service import S3StorageService
@@ -32,6 +37,9 @@ from app.utils.workspace_manifest import (
 
 
 class ChannelArtifactService:
+    UPLOADS_FOLDER = "Uploads"
+    UPLOAD_SOURCE_KIND = "user_upload"
+    _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]+")
     DEFAULT_READ_BYTES = 32 * 1024
     MAX_READ_BYTES = 64 * 1024
     TEXT_EXTENSIONS = {
@@ -71,6 +79,66 @@ class ChannelArtifactService:
             uuid.UUID(agent_identity_id_raw) if agent_identity_id_raw else None
         )
         return server_id, channel_id, agent_identity_id
+
+    @classmethod
+    def _normalize_upload_filename(cls, filename: str) -> str:
+        raw = (filename or "").strip().replace("\\", "/")
+        raw = raw.split("/")[-1].strip()
+        try:
+            raw = raw.encode("latin-1").decode("utf-8")
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            pass
+        raw = cls._CONTROL_CHARS.sub("", raw).strip()
+        return raw or "upload.bin"
+
+    @staticmethod
+    def _get_upload_size(file: UploadFile) -> int | None:
+        try:
+            file.file.seek(0, os.SEEK_END)
+            size = file.file.tell()
+            file.file.seek(0)
+            return size
+        except Exception:
+            return None
+
+    @classmethod
+    def _upload_object_key(
+        cls,
+        *,
+        server_id: uuid.UUID,
+        channel_id: uuid.UUID,
+        artifact_id: uuid.UUID,
+    ) -> str:
+        return (
+            f"channel-artifacts/{server_id}/{channel_id}/"
+            f"{cls.UPLOADS_FOLDER}/{artifact_id}/file"
+        )
+
+    @classmethod
+    def _dedupe_upload_logical_path(
+        cls,
+        db: Session,
+        *,
+        channel_id: uuid.UUID,
+        filename: str,
+    ) -> str:
+        path = PurePosixPath(filename)
+        stem = path.stem or filename
+        suffix = path.suffix
+        index = 1
+        while True:
+            display_name = filename if index == 1 else f"{stem} ({index}){suffix}"
+            logical_path = f"/{cls.UPLOADS_FOLDER}/{display_name}"
+            if (
+                ChannelArtifactRepository.get_by_channel_and_path(
+                    db,
+                    channel_id=channel_id,
+                    logical_path=logical_path,
+                )
+                is None
+            ):
+                return logical_path
+            index += 1
 
     @staticmethod
     def _resolve_object_key(
@@ -237,6 +305,77 @@ class ChannelArtifactService:
         ChannelArtifactRepository.upsert_many(db, artifacts=artifacts)
         return len(artifacts)
 
+    def upload_channel_artifact(
+        self,
+        db: Session,
+        *,
+        current_user: Any,
+        server_id: uuid.UUID,
+        channel_id: uuid.UUID,
+        file: UploadFile,
+    ) -> InputFile:
+        require_channel_member_access(
+            db,
+            server_id=server_id,
+            channel_id=channel_id,
+            user_id=current_user.id,
+        )
+        settings = get_settings()
+        max_size_bytes = settings.max_upload_size_mb * 1024 * 1024
+        size = self._get_upload_size(file)
+        if size is not None and size > max_size_bytes:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message=f"File too large. Max {settings.max_upload_size_mb}MB.",
+                details={"max_bytes": max_size_bytes, "actual_bytes": size},
+            )
+
+        artifact_id = uuid.uuid4()
+        filename = self._normalize_upload_filename(file.filename or "")
+        logical_path = self._dedupe_upload_logical_path(
+            db,
+            channel_id=channel_id,
+            filename=filename,
+        )
+        object_key = self._upload_object_key(
+            server_id=server_id,
+            channel_id=channel_id,
+            artifact_id=artifact_id,
+        )
+        self._storage.upload_fileobj(
+            fileobj=file.file,
+            key=object_key,
+            content_type=file.content_type,
+        )
+
+        artifact = ChannelArtifact(
+            id=artifact_id,
+            server_id=server_id,
+            channel_id=channel_id,
+            source_session_id=None,
+            agent_identity_id=None,
+            publisher_user_id=current_user.id,
+            source_kind=self.UPLOAD_SOURCE_KIND,
+            logical_path=logical_path,
+            display_name=PurePosixPath(logical_path).name,
+            object_key=object_key,
+            mime_type=file.content_type,
+            size_bytes=size,
+            is_previewable=True,
+        )
+        db.add(artifact)
+        db.commit()
+        db.refresh(artifact)
+        return InputFile(
+            id=str(artifact.id),
+            type="file",
+            name=artifact.display_name,
+            source=artifact.object_key,
+            size=artifact.size_bytes,
+            content_type=artifact.mime_type,
+            path=artifact.logical_path,
+        )
+
     def list_runtime_artifacts(
         self,
         db: Session,
@@ -388,7 +527,11 @@ class ChannelArtifactService:
 
         grouped_entries: dict[str, dict[str, Any]] = {}
         for artifact in artifacts:
-            if artifact.agent_identity_id is not None:
+            is_user_upload = artifact.source_kind == self.UPLOAD_SOURCE_KIND
+            if is_user_upload:
+                group_key = "uploads"
+                group_name = self.UPLOADS_FOLDER
+            elif artifact.agent_identity_id is not None:
                 group_key = f"agent:{artifact.agent_identity_id}"
                 agent = AgentIdentityRepository.get_by_id(
                     db, artifact.agent_identity_id
@@ -408,6 +551,10 @@ class ChannelArtifactService:
                 {"name": group_name, "files": [], "url_map": {}},
             )
             relative_path = artifact.logical_path.lstrip("/")
+            if is_user_upload:
+                uploads_prefix = f"{self.UPLOADS_FOLDER}/"
+                if relative_path.startswith(uploads_prefix):
+                    relative_path = relative_path[len(uploads_prefix) :]
             group["files"].append(
                 {
                     "path": relative_path,
@@ -416,7 +563,7 @@ class ChannelArtifactService:
                     "size": getattr(artifact, "size_bytes", None),
                 }
             )
-            group["url_map"][normalize_manifest_path(artifact.logical_path)] = (
+            group["url_map"][normalize_manifest_path(relative_path)] = (
                 self._storage.presign_get(
                     artifact.object_key,
                     response_content_disposition="inline",

--- a/frontend/features/servers/api/servers-api.ts
+++ b/frontend/features/servers/api/servers-api.ts
@@ -1,5 +1,5 @@
 import { apiClient, API_ENDPOINTS } from "@/services/api-client";
-import type { FileNode } from "@/features/chat/types";
+import type { FileNode, InputFile } from "@/features/chat/types";
 import type {
   ServerAgentItem,
   ServerChannelItem,
@@ -421,6 +421,19 @@ export const serversApi = {
     );
   },
 
+  uploadChannelArtifact: async (
+    serverId: string,
+    channelId: string,
+    file: File,
+  ): Promise<InputFile> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return apiClient.post<InputFile>(
+      `/servers/${serverId}/channels/${channelId}/artifacts/upload`,
+      formData,
+    );
+  },
+
   listAgentStateFiles: async (
     serverId: string,
     agentId: string,
@@ -552,18 +565,26 @@ export const serversApi = {
     channelId: string,
     input: {
       text: string;
+      attachments?: InputFile[];
       threadRootMessageId?: string | null;
       asTask?: boolean;
     },
   ): Promise<ServerConversationMessage> => {
+    const attachments = input.attachments ?? [];
+    const attachmentPreview = attachments
+      .map((item) => item.name.trim())
+      .filter(Boolean)
+      .join(", ");
+    const textPreview = input.text || attachmentPreview;
     const message = await apiClient.post<ServerConversationMessageResponse>(
       `/servers/${serverId}/channels/${channelId}/messages`,
       {
         message_type: "user",
-        text_preview: input.text,
+        text_preview: textPreview,
         thread_root_message_id: input.threadRootMessageId ?? null,
         content: {
           text: input.text,
+          attachments,
           ...(input.asTask ? { as_task: true } : {}),
         },
       },

--- a/frontend/features/servers/ui/conversation-message-row.tsx
+++ b/frontend/features/servers/ui/conversation-message-row.tsx
@@ -13,6 +13,8 @@ import {
 import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { FileCard } from "@/components/shared/file-card";
+import type { InputFile } from "@/features/chat/types";
 import {
   getUserAvatarUrl,
   getUserDisplayName,
@@ -100,6 +102,25 @@ export function getInitials(value: string): string {
 
 export function getMessageText(message: ServerConversationMessage): string {
   return getServerMessageText(message);
+}
+
+function isInputFile(value: unknown): value is InputFile {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as { name?: unknown }).name === "string" &&
+    typeof (value as { source?: unknown }).source === "string"
+  );
+}
+
+function getMessageAttachments(
+  message: ServerConversationMessage,
+): InputFile[] {
+  const attachments = message.content.attachments;
+  if (!Array.isArray(attachments)) {
+    return [];
+  }
+  return attachments.filter(isInputFile);
 }
 
 export function getMessageAuthor(message: ServerConversationMessage): string {
@@ -301,7 +322,10 @@ function StandardMessageRow({
   const [reactionPickerOpen, setReactionPickerOpen] = React.useState(false);
   const agentMessageRef = React.useRef<HTMLDivElement>(null);
   const author = getMessageAuthor(message);
-  const text = getMessageText(message);
+  const attachments = getMessageAttachments(message);
+  const contentText =
+    typeof message.content.text === "string" ? message.content.text.trim() : "";
+  const text = attachments.length > 0 ? contentText : getMessageText(message);
   const executionMessage = isExecutionMessage(message) ? message : null;
   const drilldownSessionId = getMessageSessionId(message);
   const canOpenExecutionFromAvatar =
@@ -550,7 +574,7 @@ function StandardMessageRow({
               />
             </div>
           </button>
-        ) : (
+        ) : text || attachments.length === 0 ? (
           <div className="group/message min-w-0">
             <div
               ref={agentMessageRef}
@@ -593,7 +617,19 @@ function StandardMessageRow({
               </button>
             ) : null}
           </div>
-        )}
+        ) : null}
+        {attachments.length > 0 ? (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {attachments.map((file, index) => (
+              <FileCard
+                key={`${file.source}-${index}`}
+                file={file}
+                showRemove={false}
+                className="w-full max-w-56 bg-background"
+              />
+            ))}
+          </div>
+        ) : null}
         {(message.reactions ?? []).length > 0 ? (
           <div className="flex flex-wrap gap-1.5 pt-1">
             {(message.reactions ?? []).map((reaction) => {

--- a/frontend/features/servers/ui/conversation-message-row.tsx
+++ b/frontend/features/servers/ui/conversation-message-row.tsx
@@ -204,7 +204,8 @@ function ChannelEventRow({
         </span>
         <span className="whitespace-nowrap">
           {" "}
-          · {formatTime(message.createdAt)}
+          · {formatRelativeDate(message.createdAt)}{" "}
+          {formatTime(message.createdAt)}
         </span>
       </div>
     </article>

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   Archive,
   ArrowDown,
+  ArrowUp,
   Bot,
   Check,
   ChevronLeft,
@@ -11,6 +12,9 @@ import {
   Hash,
   Lock,
   LogOut,
+  Loader2,
+  Mic,
+  MicOff,
   Plus,
   Search,
   Settings2,
@@ -43,6 +47,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { FileNode } from "@/features/chat/types";
 import { channelTasksApi } from "@/features/channel-tasks/api/channel-tasks-api";
@@ -116,6 +125,7 @@ import type {
   WorkspaceMode,
 } from "@/features/servers/ui/server-workspace-types";
 import { useUserAccount } from "@/features/user/hooks/use-user-account";
+import { appendTranscribedText, useVoiceInput } from "@/features/voice";
 import { useLanguage } from "@/hooks/use-language";
 import { useT } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
@@ -443,6 +453,8 @@ function ConversationContent({
   const mentionTrigger = React.useMemo(() => getMentionTrigger(draft), [draft]);
   const [showScrollButton, setShowScrollButton] = React.useState(false);
   const [isUserScrolling, setIsUserScrolling] = React.useState(false);
+  const draftRef = React.useRef(draft);
+  const lng = useLanguage();
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const humans = buildHumanMentionCandidates(members, currentUserId);
     const agentCandidates = agents.map(buildAgentMentionCandidate);
@@ -462,6 +474,40 @@ function ConversationContent({
   React.useEffect(() => {
     setMentionIndex(0);
   }, [mentionCandidates]);
+
+  React.useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  const syncTextareaHeight = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+  }, []);
+
+  React.useEffect(() => {
+    syncTextareaHeight();
+  }, [draft, syncTextareaHeight]);
+
+  const handleVoiceTranscription = React.useCallback(
+    (text: string) => {
+      onDraftChange(appendTranscribedText(draftRef.current, text));
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        syncTextareaHeight();
+      });
+    },
+    [onDraftChange, syncTextareaHeight],
+  );
+
+  const voiceInput = useVoiceInput({
+    t,
+    language: lng,
+    onTranscription: handleVoiceTranscription,
+  });
 
   const scrollToBottom = React.useCallback(
     (behavior: ScrollBehavior = "smooth") => {
@@ -576,7 +622,7 @@ function ConversationContent({
       !isComposingRef.current
     ) {
       event.preventDefault();
-      if (!isSending && draft.trim()) {
+      if (!isSending && !voiceInput.isBusy && draft.trim()) {
         onSend();
       }
     }
@@ -654,8 +700,8 @@ function ConversationContent({
         )}
       </div>
 
-      <div className="border-t border-border px-6 py-5">
-        <div className="relative">
+      <div className="border-t border-border px-6 py-4">
+        <div className="relative flex w-full min-w-0 items-end gap-2 rounded-lg border border-border bg-card px-3 py-2">
           {mentionTrigger && mentionCandidates.length > 0 ? (
             <div className="absolute bottom-full left-0 z-20 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 shadow-[var(--shadow-lg)]">
               <div className="px-2 pb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
@@ -695,7 +741,7 @@ function ConversationContent({
               </div>
             </div>
           ) : null}
-          <Textarea
+          <textarea
             ref={textareaRef}
             value={draft}
             onChange={(event) => onDraftChange(event.target.value)}
@@ -712,29 +758,79 @@ function ConversationContent({
             placeholder={t("conversationView.messagePlaceholder", {
               name: channel?.name ?? "",
             })}
-            className="rounded-md border-border bg-background text-base shadow-none"
+            disabled={isSending}
+            className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-1 text-sm leading-6 outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              minHeight: "2rem",
+              maxHeight: "10rem",
+            }}
           />
+          {voiceInput.isSupported ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void voiceInput.toggleRecording();
+                  }}
+                  disabled={isSending || voiceInput.status === "transcribing"}
+                  className={cn(
+                    "flex size-8 shrink-0 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                    voiceInput.status === "recording"
+                      ? "animate-pulse bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      : "text-muted-foreground hover:bg-accent",
+                  )}
+                  aria-label={
+                    voiceInput.status === "transcribing"
+                      ? t("hero.transcribingVoiceInput")
+                      : voiceInput.status === "recording"
+                        ? t("hero.stopVoiceInput")
+                        : t("hero.startVoiceInput")
+                  }
+                >
+                  {voiceInput.status === "transcribing" ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : voiceInput.status === "recording" ? (
+                    <MicOff className="size-4" />
+                  ) : (
+                    <Mic className="size-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={8}>
+                {voiceInput.status === "transcribing"
+                  ? t("hero.transcribingVoiceInput")
+                  : voiceInput.status === "recording"
+                    ? t("hero.stopVoiceInput")
+                    : t("hero.startVoiceInput")}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={isSending || voiceInput.isBusy || !draft.trim()}
+            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:opacity-50"
+            aria-label={t("conversationView.send")}
+            title={t("conversationView.send")}
+          >
+            {isSending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ArrowUp className="size-4" />
+            )}
+          </button>
         </div>
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          <label className="flex items-center gap-3 text-base text-foreground">
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+          <label className="flex items-center gap-3 text-sm text-foreground">
             <input
               type="checkbox"
               checked={asTask}
               onChange={(event) => onAsTaskChange(event.target.checked)}
-              className="size-5 rounded-none border-foreground"
+              className="size-4 rounded-sm border-foreground"
             />
             {t("conversationView.asTask")}
           </label>
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              onClick={onSend}
-              disabled={isSending || !draft.trim()}
-            >
-              {t("conversationView.send")}
-            </Button>
-          </div>
         </div>
       </div>
     </section>

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -15,9 +15,11 @@ import {
   Loader2,
   Mic,
   MicOff,
+  Paperclip,
   Plus,
   Search,
   Settings2,
+  SquareCheckBig,
   Trash2,
   UserRound,
   Users,
@@ -37,6 +39,12 @@ import {
 } from "@/components/ui/alert-dialog";
 import { FileCard } from "@/components/shared/file-card";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -808,14 +816,14 @@ function ConversationContent({
               </div>
             </div>
           ) : null}
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <button
                 type="button"
                 disabled={isSending || isUploading}
-                onClick={() => fileInputRef.current?.click()}
                 className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-                aria-label={t("hero.uploadFile")}
+                aria-label={t("conversationView.composerActions")}
+                title={t("conversationView.composerActions")}
               >
                 {isUploading ? (
                   <Loader2 className="size-4 animate-spin" />
@@ -823,16 +831,42 @@ function ConversationContent({
                   <Plus className="size-4" />
                 )}
               </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={8}>
-              {t("hero.uploadFile")}
-            </TooltipContent>
-          </Tooltip>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              side="top"
+              sideOffset={8}
+              className="w-36"
+            >
+              <DropdownMenuItem
+                disabled={isSending || isUploading}
+                onSelect={() => fileInputRef.current?.click()}
+              >
+                {isUploading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Paperclip className="size-4" />
+                )}
+                <span>{t("hero.uploadFile")}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={isSending}
+                onSelect={() => onAsTaskChange(!asTask)}
+              >
+                <SquareCheckBig
+                  className={cn("size-4", asTask ? "text-primary" : "")}
+                />
+                <span className="flex-1">{t("conversationView.asTask")}</span>
+                {asTask ? <Check className="size-4 text-primary" /> : null}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <textarea
             ref={textareaRef}
             value={draft}
             onChange={(event) => onDraftChange(event.target.value)}
             onKeyDown={handleTextareaKeyDown}
+            onInput={() => syncTextareaHeight()}
             onPaste={(event) => void handlePaste(event)}
             onCompositionStart={() => {
               isComposingRef.current = true;
@@ -842,15 +876,16 @@ function ConversationContent({
                 isComposingRef.current = false;
               });
             }}
-            rows={4}
+            rows={1}
             placeholder={t("conversationView.messagePlaceholder", {
               name: channel?.name ?? "",
             })}
             disabled={isSending}
-            className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-1 text-sm leading-6 outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 scrollbar-hide"
             style={{
               minHeight: "2rem",
               maxHeight: "10rem",
+              lineHeight: "1.5rem",
             }}
           />
           {voiceInput.isSupported ? (
@@ -917,17 +952,6 @@ function ConversationContent({
               <ArrowUp className="size-4" />
             )}
           </button>
-        </div>
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-          <label className="flex items-center gap-3 text-sm text-foreground">
-            <input
-              type="checkbox"
-              checked={asTask}
-              onChange={(event) => onAsTaskChange(event.target.checked)}
-              className="size-4 rounded-sm border-foreground"
-            />
-            {t("conversationView.asTask")}
-          </label>
         </div>
       </div>
     </section>

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { FileCard } from "@/components/shared/file-card";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -53,7 +54,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import type { FileNode } from "@/features/chat/types";
+import type { FileNode, InputFile } from "@/features/chat/types";
 import { channelTasksApi } from "@/features/channel-tasks/api/channel-tasks-api";
 import { resolveChannelTaskView } from "@/features/channel-tasks/lib/channel-task-board";
 import type {
@@ -129,10 +130,12 @@ import { appendTranscribedText, useVoiceInput } from "@/features/voice";
 import { useLanguage } from "@/hooks/use-language";
 import { useT } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
+import { playUploadSound } from "@/lib/utils/sound";
 
 const LAST_SELECTION_KEY = "poco-servers-last-selection-v1";
 const SAVED_MESSAGES_KEY = "poco-saved-messages-v1";
 const READ_MESSAGES_KEY = "poco-read-messages-v1";
+const MAX_FILE_SIZE = 100 * 1024 * 1024;
 
 type CachedServerConversationContext = {
   channels: ServerChannelItem[];
@@ -402,11 +405,15 @@ function ConversationContent({
   messages,
   savedMessageIds,
   draft,
+  attachments,
   asTask,
   isLoading,
+  isUploading,
   onDraftChange,
   onAsTaskChange,
   onSend,
+  onUploadFiles,
+  onRemoveAttachment,
   onOpenThread,
   onOpenSettings,
   onOpenMembers,
@@ -426,11 +433,15 @@ function ConversationContent({
   messages: ServerConversationMessage[];
   savedMessageIds: Set<string>;
   draft: string;
+  attachments: InputFile[];
   asTask: boolean;
   isLoading: boolean;
+  isUploading: boolean;
   onDraftChange: (value: string) => void;
   onAsTaskChange: (value: boolean) => void;
   onSend: () => void;
+  onUploadFiles: (files: File[]) => Promise<void>;
+  onRemoveAttachment: (index: number) => void;
   onOpenThread: (message: ServerConversationMessage) => void;
   onOpenSettings: () => void;
   onOpenMembers: () => void;
@@ -445,6 +456,7 @@ function ConversationContent({
 }) {
   const { t } = useT("translation");
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
   const isComposingRef = React.useRef(false);
   const Icon = channel?.conversationType === "direct_message" ? Lock : Hash;
   const scrollContainerRef = React.useRef<HTMLDivElement | null>(null);
@@ -622,10 +634,46 @@ function ConversationContent({
       !isComposingRef.current
     ) {
       event.preventDefault();
-      if (!isSending && !voiceInput.isBusy && draft.trim()) {
+      if (
+        !isSending &&
+        !isUploading &&
+        !voiceInput.isBusy &&
+        (draft.trim() || attachments.length > 0)
+      ) {
         onSend();
       }
     }
+  };
+
+  const handleFileSelect = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const input = event.currentTarget;
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) {
+      return;
+    }
+    try {
+      await onUploadFiles(files);
+    } finally {
+      input.value = "";
+    }
+  };
+
+  const handlePaste = async (
+    event: React.ClipboardEvent<HTMLTextAreaElement>,
+  ) => {
+    const items = event.clipboardData?.items;
+    if (!items) {
+      return;
+    }
+    const file = Array.from(items)
+      .find((item) => item.kind === "file")
+      ?.getAsFile();
+    if (!file) {
+      return;
+    }
+    await onUploadFiles([file]);
   };
 
   return (
@@ -701,6 +749,25 @@ function ConversationContent({
       </div>
 
       <div className="border-t border-border px-6 py-4">
+        <input
+          type="file"
+          multiple
+          ref={fileInputRef}
+          className="hidden"
+          onChange={(event) => void handleFileSelect(event)}
+        />
+        {attachments.length > 0 ? (
+          <div className="mb-2 flex min-w-0 flex-wrap gap-2 px-3">
+            {attachments.map((file, index) => (
+              <FileCard
+                key={`${file.source}-${index}`}
+                file={file}
+                onRemove={() => onRemoveAttachment(index)}
+                className="w-full max-w-48 bg-background"
+              />
+            ))}
+          </div>
+        ) : null}
         <div className="relative flex w-full min-w-0 items-end gap-2 rounded-lg border border-border bg-card px-3 py-2">
           {mentionTrigger && mentionCandidates.length > 0 ? (
             <div className="absolute bottom-full left-0 z-20 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 shadow-[var(--shadow-lg)]">
@@ -741,11 +808,32 @@ function ConversationContent({
               </div>
             </div>
           ) : null}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                disabled={isSending || isUploading}
+                onClick={() => fileInputRef.current?.click()}
+                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={t("hero.uploadFile")}
+              >
+                {isUploading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={8}>
+              {t("hero.uploadFile")}
+            </TooltipContent>
+          </Tooltip>
           <textarea
             ref={textareaRef}
             value={draft}
             onChange={(event) => onDraftChange(event.target.value)}
             onKeyDown={handleTextareaKeyDown}
+            onPaste={(event) => void handlePaste(event)}
             onCompositionStart={() => {
               isComposingRef.current = true;
             }}
@@ -773,7 +861,11 @@ function ConversationContent({
                   onClick={() => {
                     void voiceInput.toggleRecording();
                   }}
-                  disabled={isSending || voiceInput.status === "transcribing"}
+                  disabled={
+                    isSending ||
+                    isUploading ||
+                    voiceInput.status === "transcribing"
+                  }
                   className={cn(
                     "flex size-8 shrink-0 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                     voiceInput.status === "recording"
@@ -809,7 +901,12 @@ function ConversationContent({
           <button
             type="button"
             onClick={onSend}
-            disabled={isSending || voiceInput.isBusy || !draft.trim()}
+            disabled={
+              isSending ||
+              isUploading ||
+              voiceInput.isBusy ||
+              (!draft.trim() && attachments.length === 0)
+            }
             className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:opacity-50"
             aria-label={t("conversationView.send")}
             title={t("conversationView.send")}
@@ -1685,10 +1782,14 @@ export function ServerConversationPageClient({
     [],
   );
   const [draft, setDraft] = React.useState("");
+  const [draftAttachments, setDraftAttachments] = React.useState<InputFile[]>(
+    [],
+  );
   const [threadDraft, setThreadDraft] = React.useState("");
   const [searchValue, setSearchValue] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(!cachedServerContext);
   const [isSending, setIsSending] = React.useState(false);
+  const [isUploadingDraftFile, setIsUploadingDraftFile] = React.useState(false);
   const [asTask, setAsTask] = React.useState(false);
   const [threadAsTask, setThreadAsTask] = React.useState(false);
   const [savedMessageIds, setSavedMessageIds] = React.useState<Set<string>>(
@@ -2163,6 +2264,11 @@ export function ServerConversationPageClient({
   ]);
 
   React.useEffect(() => {
+    setDraftAttachments([]);
+    setIsUploadingDraftFile(false);
+  }, [activeChannelId]);
+
+  React.useEffect(() => {
     if (!selectedServerId || channels.length === 0) {
       return;
     }
@@ -2445,12 +2551,80 @@ export function ServerConversationPageClient({
     [channels, openChannel],
   );
 
+  const uploadDraftFiles = React.useCallback(
+    async (files: File[]) => {
+      if (!selectedServerId || !activeChannelId || files.length === 0) {
+        return;
+      }
+
+      const existingNames = new Set(
+        draftAttachments
+          .map((item) => (item.name || "").trim().toLowerCase())
+          .filter(Boolean),
+      );
+
+      setIsUploadingDraftFile(true);
+      try {
+        let uploadedAny = false;
+        for (const file of files) {
+          const normalizedName = file.name.trim().toLowerCase();
+          if (existingNames.has(normalizedName)) {
+            toast.error(
+              t("hero.toasts.duplicateFileName", {
+                name: file.name,
+              }),
+            );
+            continue;
+          }
+
+          if (file.size > MAX_FILE_SIZE) {
+            toast.error(t("hero.toasts.fileTooLarge"));
+            continue;
+          }
+
+          try {
+            const uploadedFile = await serversApi.uploadChannelArtifact(
+              selectedServerId,
+              activeChannelId,
+              file,
+            );
+            setDraftAttachments((current) => [...current, uploadedFile]);
+            existingNames.add(normalizedName);
+            uploadedAny = true;
+            toast.success(t("hero.toasts.uploadSuccess"));
+            playUploadSound();
+          } catch (error) {
+            console.error("[ServersWorkspace] channel upload failed", error);
+            toast.error(t("hero.toasts.uploadFailed"));
+          }
+        }
+
+        if (uploadedAny) {
+          setChannelArtifacts(
+            await serversApi.listChannelArtifacts(
+              selectedServerId,
+              activeChannelId,
+            ),
+          );
+        }
+      } finally {
+        setIsUploadingDraftFile(false);
+      }
+    },
+    [activeChannelId, draftAttachments, selectedServerId, t],
+  );
+
+  const removeDraftAttachment = React.useCallback((index: number) => {
+    setDraftAttachments((current) => current.filter((_, i) => i !== index));
+  }, []);
+
   const handleSend = async () => {
     if (!selectedServerId || !activeChannelId) {
       return;
     }
     const content = draft.trim();
-    if (!content) {
+    const attachments = [...draftAttachments];
+    if (!content && attachments.length === 0) {
       return;
     }
     setIsSending(true);
@@ -2461,23 +2635,29 @@ export function ServerConversationPageClient({
           activeChannelId,
           {
             text: content,
+            attachments,
             asTask: true,
           },
         );
         const title =
-          content.split("\n")[0]?.trim().slice(0, 80) || content.slice(0, 80);
+          content.split("\n")[0]?.trim().slice(0, 80) ||
+          attachments[0]?.name.slice(0, 80) ||
+          content.slice(0, 80);
         await channelTasksApi.createTask(selectedServerId, activeChannelId, {
           title,
-          description: content,
+          description:
+            content || attachments.map((item) => item.name).join("\n"),
           sourceMessageId: message.id,
         });
         toast.success(t("conversationView.toasts.taskCreated"));
       } else {
         await serversApi.sendMessage(selectedServerId, activeChannelId, {
           text: content,
+          attachments,
         });
       }
       setDraft("");
+      setDraftAttachments([]);
       setAsTask(false);
       const messages = await serversApi.listMessages(
         selectedServerId,
@@ -3381,11 +3561,15 @@ export function ServerConversationPageClient({
                 messages={currentMessages}
                 savedMessageIds={savedMessageIds}
                 draft={draft}
+                attachments={draftAttachments}
                 asTask={asTask}
                 isLoading={isLoading}
+                isUploading={isUploadingDraftFile}
                 onDraftChange={setDraft}
                 onAsTaskChange={setAsTask}
                 onSend={() => void handleSend()}
+                onUploadFiles={uploadDraftFiles}
+                onRemoveAttachment={removeDraftAttachment}
                 onOpenThread={(message) =>
                   setDrawer({
                     type: "thread",

--- a/frontend/features/servers/ui/shared-artifacts-drawer.tsx
+++ b/frontend/features/servers/ui/shared-artifacts-drawer.tsx
@@ -95,9 +95,6 @@ export function SharedArtifactsDrawer({
             <p className="text-xl font-semibold text-foreground">
               {t("conversationView.sharedArtifacts.title")}
             </p>
-            <p className="truncate text-sm text-muted-foreground">
-              {t("conversationView.sharedArtifacts.description")}
-            </p>
           </div>
         </div>
         <Button type="button" variant="outline" size="sm" onClick={onClose}>

--- a/frontend/features/voice/api/voice-api.ts
+++ b/frontend/features/voice/api/voice-api.ts
@@ -4,6 +4,10 @@ export interface AudioTranscriptionResult {
   text: string;
 }
 
+interface AudioTranscriptionSupportResult {
+  available: boolean;
+}
+
 interface TranscribeAudioOptions {
   language?: string;
   signal?: AbortSignal;
@@ -28,5 +32,11 @@ export async function transcribeAudio(
       signal: options.signal,
       timeoutMs: 180_000,
     },
+  );
+}
+
+export async function getAudioTranscriptionSupport(): Promise<AudioTranscriptionSupportResult> {
+  return apiClient.get<AudioTranscriptionSupportResult>(
+    API_ENDPOINTS.audioTranscriptionSupport,
   );
 }

--- a/frontend/features/voice/model/use-voice-input.ts
+++ b/frontend/features/voice/model/use-voice-input.ts
@@ -5,7 +5,10 @@ import { toast } from "sonner";
 
 import { ApiError } from "@/lib/errors";
 
-import { transcribeAudio } from "@/features/voice/api/voice-api";
+import {
+  getAudioTranscriptionSupport,
+  transcribeAudio,
+} from "@/features/voice/api/voice-api";
 
 export type VoiceInputStatus = "idle" | "recording" | "transcribing";
 
@@ -27,6 +30,33 @@ const RECORDING_FORMAT_CANDIDATES: RecordingFormat[] = [
   { mimeType: "audio/ogg;codecs=opus", extension: "ogg" },
   { mimeType: "audio/ogg", extension: "ogg" },
 ];
+
+let cachedServerSupport: boolean | null = null;
+let serverSupportRequest: Promise<boolean> | null = null;
+
+async function resolveServerSupport(): Promise<boolean> {
+  if (cachedServerSupport !== null) {
+    return cachedServerSupport;
+  }
+
+  if (!serverSupportRequest) {
+    serverSupportRequest = getAudioTranscriptionSupport()
+      .then((result) => {
+        cachedServerSupport = result.available;
+        return result.available;
+      })
+      .catch((error) => {
+        console.warn("[VoiceInput] Failed to resolve voice input support:", error);
+        cachedServerSupport = false;
+        return false;
+      })
+      .finally(() => {
+        serverSupportRequest = null;
+      });
+  }
+
+  return serverSupportRequest;
+}
 
 function isVoiceInputSupported(): boolean {
   if (typeof window === "undefined") {
@@ -78,7 +108,10 @@ export function useVoiceInput({
   language,
 }: UseVoiceInputOptions) {
   const [status, setStatus] = React.useState<VoiceInputStatus>("idle");
-  const isSupported = isVoiceInputSupported();
+  const [serverSupport, setServerSupport] = React.useState(
+    cachedServerSupport ?? false,
+  );
+  const isSupported = isVoiceInputSupported() && serverSupport;
 
   const mediaRecorderRef = React.useRef<MediaRecorder | null>(null);
   const mediaStreamRef = React.useRef<MediaStream | null>(null);
@@ -91,6 +124,24 @@ export function useVoiceInput({
   React.useEffect(() => {
     onTranscriptionRef.current = onTranscription;
   }, [onTranscription]);
+
+  React.useEffect(() => {
+    if (!isVoiceInputSupported()) {
+      return;
+    }
+
+    let active = true;
+
+    void resolveServerSupport().then((available) => {
+      if (active) {
+        setServerSupport(available);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const updateStatus = React.useCallback((nextStatus: VoiceInputStatus) => {
     if (isMountedRef.current) {

--- a/frontend/features/voice/model/use-voice-input.ts
+++ b/frontend/features/voice/model/use-voice-input.ts
@@ -46,7 +46,10 @@ async function resolveServerSupport(): Promise<boolean> {
         return result.available;
       })
       .catch((error) => {
-        console.warn("[VoiceInput] Failed to resolve voice input support:", error);
+        console.warn(
+          "[VoiceInput] Failed to resolve voice input support:",
+          error,
+        );
         cachedServerSupport = false;
         return false;
       })

--- a/frontend/lib/i18n/locales/de/translation.json
+++ b/frontend/lib/i18n/locales/de/translation.json
@@ -227,9 +227,9 @@
     "unread": "Ungelesen",
     "noInbox": "Noch keine Einträge im Posteingang",
     "noSaved": "Noch keine gespeicherten Einträge",
+    "composerActions": "Weitere Aktionen",
     "sharedArtifacts": {
       "title": "Shared files",
-      "description": "Published artifacts grouped by agent",
       "preview": "Preview",
       "empty": "No published files yet"
     },

--- a/frontend/lib/i18n/locales/en/translation.json
+++ b/frontend/lib/i18n/locales/en/translation.json
@@ -228,9 +228,9 @@
     "unread": "Unread",
     "noInbox": "No inbox items yet",
     "noSaved": "No saved items yet",
+    "composerActions": "More actions",
     "sharedArtifacts": {
       "title": "Shared files",
-      "description": "Published artifacts grouped by agent",
       "preview": "Preview",
       "empty": "No published files yet"
     },

--- a/frontend/lib/i18n/locales/fr/translation.json
+++ b/frontend/lib/i18n/locales/fr/translation.json
@@ -227,9 +227,9 @@
     "unread": "Non lus",
     "noInbox": "Aucun élément dans la boîte de réception",
     "noSaved": "Aucun élément enregistré",
+    "composerActions": "Plus d’actions",
     "sharedArtifacts": {
       "title": "Shared files",
-      "description": "Published artifacts grouped by agent",
       "preview": "Preview",
       "empty": "No published files yet"
     },

--- a/frontend/lib/i18n/locales/ja/translation.json
+++ b/frontend/lib/i18n/locales/ja/translation.json
@@ -227,9 +227,9 @@
     "unread": "未読",
     "noInbox": "受信箱に項目はまだありません",
     "noSaved": "保存済み項目はまだありません",
+    "composerActions": "その他の操作",
     "sharedArtifacts": {
       "title": "Shared files",
-      "description": "Published artifacts grouped by agent",
       "preview": "Preview",
       "empty": "No published files yet"
     },

--- a/frontend/lib/i18n/locales/ru/translation.json
+++ b/frontend/lib/i18n/locales/ru/translation.json
@@ -227,9 +227,9 @@
     "unread": "Непрочитанные",
     "noInbox": "Во входящих пока ничего нет",
     "noSaved": "Сохранённых элементов пока нет",
+    "composerActions": "Другие действия",
     "sharedArtifacts": {
       "title": "Shared files",
-      "description": "Published artifacts grouped by agent",
       "preview": "Preview",
       "empty": "No published files yet"
     },

--- a/frontend/lib/i18n/locales/zh/translation.json
+++ b/frontend/lib/i18n/locales/zh/translation.json
@@ -228,9 +228,9 @@
     "unread": "未读",
     "noInbox": "收件箱暂无内容",
     "noSaved": "暂无已保存内容",
+    "composerActions": "更多操作",
     "sharedArtifacts": {
       "title": "共享文件",
-      "description": "按 Agent 分组展示的公开成果",
       "preview": "预览",
       "empty": "还没有公开材料"
     },

--- a/frontend/services/api-client.ts
+++ b/frontend/services/api-client.ts
@@ -109,6 +109,7 @@ export const API_ENDPOINTS = {
   // Attachments
   attachmentsUpload: "/attachments/upload",
   audioTranscriptions: "/audio/transcriptions",
+  audioTranscriptionSupport: "/audio/transcriptions/support",
 
   // Environment Variables
   envVars: "/env-vars",


### PR DESCRIPTION
## 变更
- 对齐频道事件时间与输入框样式，收起「上传文件 / 转为任务」到更紧凑的 + 菜单。
- 支持频道内文件上传到共享 Uploads，并在消息与共享文件中展示。
- 未配置音频转写时隐藏语音输入按钮。
<img width="1284" height="770" alt="image" src="https://github.com/user-attachments/assets/b20ddfd3-9661-4016-ade8-1964fa4d3bc9" />
