### PR TITLE
Protect host ~/.claude during executor workspace setup

### DIFF
--- a/executor/app/core/workspace.py
+++ b/executor/app/core/workspace.py
@@ -65,8 +65,44 @@ class WorkspaceManager:
         self._ensure_inputs_dir(self.work_path)
         self._ensure_git_excludes(self.work_path)
 
+    @staticmethod
+    def _destructive_claude_symlink_allowed() -> bool:
+        """The ~/.claude rmtree+symlink swap is only safe inside a disposable
+        container, where ~/.claude is throwaway. On a host it would destroy the
+        user's REAL Claude Code data (chat history under ~/.claude/projects).
+
+        Only allow it when we can positively confirm a container context, or
+        when explicitly forced via env. Default = refuse (protect host data).
+        """
+        if os.environ.get("POCO_FORCE_CLAUDE_SYMLINK") == "1":
+            return True
+        if os.environ.get("POCO_IN_CONTAINER"):
+            return True
+        if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():
+            return True
+        try:
+            cgroup = Path("/proc/1/cgroup").read_text()
+            if any(tok in cgroup for tok in ("docker", "containerd", "kubepods", "lxc")):
+                return True
+        except Exception:
+            pass
+        return False
+
     async def _setup_session_persistence(self):
         self.persistent_claude_data.mkdir(exist_ok=True)
+
+        if not self._destructive_claude_symlink_allowed():
+            # Running on a host (not a disposable container): do NOT touch the
+            # user's real ~/.claude. Skip the symlink swap; the agent will use
+            # the host ~/.claude directly. Set POCO_FORCE_CLAUDE_SYMLINK=1 only
+            # inside an isolated container if you really want the swap.
+            logger.warning(
+                "Skipping ~/.claude symlink swap: no container context detected "
+                "(%s). Refusing to rmtree host data. Set POCO_IN_CONTAINER=1 "
+                "inside a container to enable.",
+                self.system_claude_home,
+            )
+            return
 
         if self.system_claude_home.exists() or self.system_claude_home.is_symlink():
             if self.system_claude_home.is_symlink():
@@ -77,8 +113,12 @@ class WorkspaceManager:
         self.system_claude_home.symlink_to(self.persistent_claude_data)
 
     async def cleanup(self):
-        # Restore system ~/.claude if it was symlinked
-        if self.system_claude_home.is_symlink():
+        # Restore system ~/.claude if it was symlinked. Only unlink a symlink
+        # that points at OUR persistent_claude_data, never an unrelated one.
+        if (
+            self.system_claude_home.is_symlink()
+            and self.system_claude_home.resolve() == self.persistent_claude_data.resolve()
+        ):
             self.system_claude_home.unlink()
         # Best-effort cleanup for temporary askpass helper.
         if self._git_askpass_path:

--- a/executor/tests/test_workspace_manager.py
+++ b/executor/tests/test_workspace_manager.py
@@ -1,0 +1,60 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.workspace import WorkspaceManager
+
+
+class WorkspaceManagerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_setup_session_persistence_skips_host_claude_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_path = Path(temp_dir) / "workspace"
+            root_path.mkdir(parents=True)
+            claude_home = Path(temp_dir) / "home" / ".claude"
+            claude_home.mkdir(parents=True)
+            sentinel = claude_home / "projects" / "sentinel.txt"
+            sentinel.parent.mkdir(parents=True)
+            sentinel.write_text("keep", encoding="utf-8")
+
+            manager = WorkspaceManager(mount_path=str(root_path))
+            manager.system_claude_home = claude_home
+
+            with patch.object(
+                WorkspaceManager,
+                "_destructive_claude_symlink_allowed",
+                return_value=False,
+            ):
+                await manager._setup_session_persistence()
+
+            self.assertTrue(sentinel.exists())
+            self.assertFalse(claude_home.is_symlink())
+            self.assertTrue((root_path / ".claude_data").exists())
+
+    async def test_cleanup_only_unlinks_managed_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_path = Path(temp_dir) / "workspace"
+            root_path.mkdir(parents=True)
+            managed_target = root_path / ".claude_data"
+            managed_target.mkdir()
+
+            manager = WorkspaceManager(mount_path=str(root_path))
+            claude_home = Path(temp_dir) / "home" / ".claude"
+            claude_home.parent.mkdir(parents=True)
+            manager.system_claude_home = claude_home
+            manager.system_claude_home.symlink_to(managed_target)
+
+            await manager.cleanup()
+            self.assertFalse(manager.system_claude_home.exists())
+
+            other_target = Path(temp_dir) / "other-claude"
+            other_target.mkdir()
+            manager.system_claude_home.symlink_to(other_target)
+
+            await manager.cleanup()
+            self.assertTrue(manager.system_claude_home.is_symlink())
+            self.assertEqual(manager.system_claude_home.resolve(), other_target.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- gate the destructive ~/.claude symlink swap behind explicit container detection or override
- skip deleting host Claude data when executor runs outside a disposable container
- only unlink ~/.claude during cleanup when it points to Poco-managed .claude_data
- add regression tests for host preservation and managed symlink cleanup

## Testing
- cd executor && uv run python -m unittest tests.test_workspace_manager tests.test_workspace_hook tests.test_engine_response_loop

Closes #131