### PR TITLE
加固 Executor Manager 接口鉴权

### DIFF
--- a/COMMIT.md
+++ b/COMMIT.md
@@ -1,6 +1,6 @@
-fix(server-channel): name agent direct messages by handle
+fix(executor-manager): require tokens for manager APIs
 
-- Create agent direct-message channels with @handle names and handle-based slugs
-- Project existing agent DMs with current handles when listing channels
-- Keep newly opened DMs in local channel state before routing to the conversation
-- Cover agent DM naming and legacy projection behavior in backend tests
+- Protect EM control-plane routes with X-Internal-Token and executor proxy routes with callback tokens
+- Send internal headers from Backend EM clients and callback Bearer tokens from executor clients
+- Add auth regression coverage for EM routes, Backend callers, and executor manager clients
+- Record the token boundary decision and completed hardening plan

--- a/backend/app/api/v1/schedules.py
+++ b/backend/app/api/v1/schedules.py
@@ -21,7 +21,10 @@ async def get_schedules() -> JSONResponse:
     url = f"{settings.executor_manager_url}/api/v1/schedules"
 
     try:
-        headers = {"accept": "application/json"}
+        headers = {
+            "accept": "application/json",
+            "X-Internal-Token": settings.internal_api_token,
+        }
         request_id = get_request_id()
         if request_id:
             headers["X-Request-ID"] = request_id

--- a/backend/app/services/executor_manager_client.py
+++ b/backend/app/services/executor_manager_client.py
@@ -7,6 +7,7 @@ class ExecutorManagerClient:
     def __init__(self) -> None:
         settings = get_settings()
         self._base_url = (settings.executor_manager_url or "").rstrip("/")
+        self._internal_headers = {"X-Internal-Token": settings.internal_api_token}
         self._client = httpx.Client(
             base_url=self._base_url,
             timeout=httpx.Timeout(connect=3.0, read=10.0, write=10.0, pool=3.0),
@@ -17,4 +18,5 @@ class ExecutorManagerClient:
         self._client.post(
             "/api/v1/executor/delete",
             json={"container_id": container_id, "reason": "Agent assignment release"},
+            headers=self._internal_headers,
         ).raise_for_status()

--- a/backend/tests/test_executor_manager_client.py
+++ b/backend/tests/test_executor_manager_client.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.services.executor_manager_client import ExecutorManagerClient
+
+
+class ExecutorManagerClientTests(unittest.TestCase):
+    def test_delete_container_sends_internal_token(self) -> None:
+        settings = MagicMock(
+            executor_manager_url="http://executor-manager",
+            internal_api_token="internal-token",
+        )
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        http_client = MagicMock()
+        http_client.post.return_value = response
+
+        with (
+            patch(
+                "app.services.executor_manager_client.get_settings",
+                return_value=settings,
+            ),
+            patch(
+                "app.services.executor_manager_client.httpx.Client",
+                return_value=http_client,
+            ),
+        ):
+            ExecutorManagerClient().delete_container("container-1")
+
+        http_client.post.assert_called_once()
+        _, kwargs = http_client.post.call_args
+        self.assertEqual(kwargs["headers"]["X-Internal-Token"], "internal-token")
+        self.assertEqual(kwargs["json"]["container_id"], "container-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_schedules_proxy.py
+++ b/backend/tests/test_schedules_proxy.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1.schedules import router
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    def read(self) -> bytes:
+        return b'{"code":0,"data":{"rules":[]},"message":"ok"}'
+
+
+class SchedulesProxyTests(unittest.TestCase):
+    def test_schedules_proxy_sends_internal_token_to_executor_manager(self) -> None:
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+        settings = MagicMock(
+            executor_manager_url="http://executor-manager",
+            internal_api_token="internal-token",
+        )
+
+        with (
+            patch("app.api.v1.schedules.get_settings", return_value=settings),
+            patch("app.api.v1.schedules.urlopen", return_value=_Response()) as open_url,
+        ):
+            response = TestClient(app).get("/api/v1/schedules")
+
+        self.assertEqual(response.status_code, 200)
+        request = open_url.call_args.args[0]
+        self.assertEqual(request.get_header("X-internal-token"), "internal-token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor/app/api/v1/task.py
+++ b/executor/app/api/v1/task.py
@@ -50,19 +50,36 @@ async def run_task(req: TaskRun, background_tasks: BackgroundTasks) -> dict:
     Returns:
         Accepted status with session ID.
     """
-    callback_client = CallbackClient(callback_url=req.callback_url)
+    callback_client = CallbackClient(
+        callback_url=req.callback_url,
+        callback_token=req.callback_token,
+    )
     base_url = UserInputClient.resolve_base_url(
         callback_url=req.callback_url, callback_base_url=req.callback_base_url
     )
-    user_input_client = UserInputClient(base_url=base_url)
-    computer_client = ComputerClient(base_url=base_url)
+    user_input_client = UserInputClient(
+        base_url=base_url,
+        callback_token=req.callback_token,
+    )
+    computer_client = ComputerClient(
+        base_url=base_url,
+        callback_token=req.callback_token,
+    )
     memory_client = (
-        MemoryClient(base_url=base_url, session_id=req.session_id)
+        MemoryClient(
+            base_url=base_url,
+            session_id=req.session_id,
+            callback_token=req.callback_token,
+        )
         if req.config.memory_enabled
         else None
     )
     channel_runtime_client = (
-        ChannelRuntimeClient(base_url=base_url, session_id=req.session_id)
+        ChannelRuntimeClient(
+            base_url=base_url,
+            session_id=req.session_id,
+            callback_token=req.callback_token,
+        )
         if req.config.server_id
         and req.config.channel_id
         and req.config.agent_identity_id

--- a/executor/app/core/callback.py
+++ b/executor/app/core/callback.py
@@ -10,9 +10,24 @@ from app.core.observability.request_context import (
 
 
 class CallbackClient:
-    def __init__(self, callback_url: str, timeout: float = 30.0):
+    def __init__(
+        self,
+        callback_url: str,
+        callback_token: str = "",
+        timeout: float = 30.0,
+    ):
         self.callback_url = callback_url
+        self.callback_token = callback_token
         self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def send(self, report: AgentCallbackRequest) -> bool:
         try:
@@ -20,10 +35,7 @@ class CallbackClient:
                 response = await client.post(
                     self.callback_url,
                     json=report.model_dump(mode="json"),
-                    headers={
-                        "X-Request-ID": get_request_id() or generate_request_id(),
-                        "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                    },
+                    headers=self._headers(),
                 )
                 return response.is_success
         except httpx.RequestError:

--- a/executor/app/core/channel_runtime.py
+++ b/executor/app/core/channel_runtime.py
@@ -75,24 +75,33 @@ def stage_downloaded_artifact(
 
 
 class ChannelRuntimeClient:
-    def __init__(self, base_url: str, session_id: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        session_id: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session_id = session_id
+        self.callback_token = callback_token
         self.timeout = timeout
 
-    @staticmethod
-    def _trace_headers() -> dict[str, str]:
-        return {
+    def _headers(self) -> dict[str, str]:
+        headers = {
             "X-Request-ID": get_request_id() or generate_request_id(),
             "X-Trace-ID": get_trace_id() or generate_trace_id(),
         }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def _request(self, path: str, payload: dict[str, Any]) -> Any:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.base_url}{path}",
                 json={"session_id": self.session_id, **payload},
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
 
         body = response.json()
@@ -222,7 +231,7 @@ class ChannelRuntimeClient:
                     "artifact_id": artifact_id,
                     "logical_path": logical_path,
                 },
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
 
         if response.is_error:

--- a/executor/app/core/computer.py
+++ b/executor/app/core/computer.py
@@ -15,9 +15,24 @@ logger = logging.getLogger(__name__)
 class ComputerClient:
     """Client for sending Poco Computer artifacts to Executor Manager."""
 
-    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.callback_token = callback_token
         self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def upload_browser_screenshot(
         self,
@@ -39,10 +54,7 @@ class ComputerClient:
                     files={
                         "file": ("screenshot.png", png_bytes, "image/png"),
                     },
-                    headers={
-                        "X-Request-ID": get_request_id() or generate_request_id(),
-                        "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                    },
+                    headers=self._headers(),
                 )
                 if not response.is_success:
                     logger.warning(

--- a/executor/app/core/memory.py
+++ b/executor/app/core/memory.py
@@ -18,17 +18,26 @@ MEMORY_MCP_SERVER_KEY = "__poco_memory"
 class MemoryClient:
     """Client for manager memory proxy APIs."""
 
-    def __init__(self, base_url: str, session_id: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        session_id: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session_id = session_id
+        self.callback_token = callback_token
         self.timeout = timeout
 
-    @staticmethod
-    def _trace_headers() -> dict[str, str]:
-        return {
+    def _headers(self) -> dict[str, str]:
+        headers = {
             "X-Request-ID": get_request_id() or generate_request_id(),
             "X-Trace-ID": get_trace_id() or generate_trace_id(),
         }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def _request(
         self,
@@ -44,7 +53,7 @@ class MemoryClient:
                 url=f"{self.base_url}{path}",
                 params=params,
                 json=json_body,
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
             response.raise_for_status()
 

--- a/executor/app/core/user_input.py
+++ b/executor/app/core/user_input.py
@@ -16,10 +16,12 @@ class UserInputClient:
     def __init__(
         self,
         base_url: str,
+        callback_token: str = "",
         timeout: float = 10.0,
         poll_interval: float = 0.5,
     ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.callback_token = callback_token
         self.timeout = timeout
         self.poll_interval = poll_interval
 
@@ -31,15 +33,21 @@ class UserInputClient:
             return callback_url[: -len("/api/v1/callback")]
         return callback_url.rstrip("/")
 
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
+
     async def create_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.base_url}/api/v1/user-input-requests",
                 json=payload,
-                headers={
-                    "X-Request-ID": get_request_id() or generate_request_id(),
-                    "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                },
+                headers=self._headers(),
             )
             response.raise_for_status()
             data = response.json()
@@ -49,10 +57,7 @@ class UserInputClient:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.get(
                 f"{self.base_url}/api/v1/user-input-requests/{request_id}",
-                headers={
-                    "X-Request-ID": get_request_id() or generate_request_id(),
-                    "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                },
+                headers=self._headers(),
             )
             response.raise_for_status()
             data = response.json()

--- a/executor/tests/test_manager_auth_clients.py
+++ b/executor/tests/test_manager_auth_clients.py
@@ -126,21 +126,21 @@ class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
         from app.schemas.request import TaskConfig, TaskRun
 
         background_tasks = MagicMock()
-        created_clients: dict[str, object] = {}
+        created_clients: dict[str, dict[str, object]] = {}
 
-        def callback_factory(**kwargs):
+        def callback_factory(**kwargs: object):
             created_clients["callback"] = kwargs
             return AsyncMock()
 
-        def user_input_factory(**kwargs):
+        def user_input_factory(**kwargs: object):
             created_clients["user_input"] = kwargs
             return AsyncMock()
 
-        def computer_factory(**kwargs):
+        def computer_factory(**kwargs: object):
             created_clients["computer"] = kwargs
             return AsyncMock()
 
-        def memory_factory(**kwargs):
+        def memory_factory(**kwargs: object):
             created_clients["memory"] = kwargs
             return AsyncMock()
 
@@ -167,7 +167,9 @@ class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result["status"], "accepted")
         self.assertEqual(created_clients["callback"]["callback_token"], CALLBACK_TOKEN)
-        self.assertEqual(created_clients["user_input"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(
+            created_clients["user_input"]["callback_token"], CALLBACK_TOKEN
+        )
         self.assertEqual(created_clients["computer"]["callback_token"], CALLBACK_TOKEN)
         self.assertEqual(created_clients["memory"]["callback_token"], CALLBACK_TOKEN)
 

--- a/executor/tests/test_manager_auth_clients.py
+++ b/executor/tests/test_manager_auth_clients.py
@@ -1,0 +1,176 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from app.core.callback import CallbackClient
+from app.core.channel_runtime import ChannelRuntimeClient
+from app.core.memory import MemoryClient
+from app.core.user_input import UserInputClient
+from app.schemas.callback import AgentCallbackRequest, CallbackStatus
+
+
+CALLBACK_TOKEN = "callback-token"
+
+
+class FakeAsyncClient:
+    requests: list[dict]
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.__class__.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    async def post(self, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": "POST", "url": url, **kwargs})
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+    async def get(self, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": "GET", "url": url, **kwargs})
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+    async def request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": method, "url": url, **kwargs})
+        request = httpx.Request(method, url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+
+class ManagerAuthClientTests(unittest.IsolatedAsyncioTestCase):
+    def assertBearerHeader(self, request: dict) -> None:
+        self.assertEqual(
+            request["headers"]["Authorization"],
+            f"Bearer {CALLBACK_TOKEN}",
+        )
+
+    async def test_callback_client_sends_callback_token(self) -> None:
+        client = CallbackClient(
+            callback_url="http://manager/api/v1/callback",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.callback.httpx.AsyncClient", FakeAsyncClient):
+            sent = await client.send(
+                AgentCallbackRequest(
+                    session_id="session-1",
+                    status=CallbackStatus.RUNNING,
+                    progress=10,
+                )
+            )
+
+        self.assertTrue(sent)
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_memory_client_sends_callback_token(self) -> None:
+        client = MemoryClient(
+            base_url="http://manager",
+            session_id="session-1",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.memory.httpx.AsyncClient", FakeAsyncClient):
+            await client.list_memories()
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_channel_runtime_client_sends_callback_token(self) -> None:
+        client = ChannelRuntimeClient(
+            base_url="http://manager",
+            session_id="session-1",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.channel_runtime.httpx.AsyncClient", FakeAsyncClient):
+            await client.list_agents()
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_user_input_client_sends_callback_token(self) -> None:
+        client = UserInputClient(
+            base_url="http://manager",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.user_input.httpx.AsyncClient", FakeAsyncClient):
+            await client.get_request("request-1")
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_computer_client_sends_callback_token(self) -> None:
+        from app.core.computer import ComputerClient
+
+        client = ComputerClient(
+            base_url="http://manager",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.computer.httpx.AsyncClient", FakeAsyncClient):
+            await client.upload_browser_screenshot(
+                session_id="session-1",
+                run_id=None,
+                tool_use_id="tool-1",
+                png_bytes=b"data",
+            )
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+
+class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_task_passes_callback_token_to_manager_clients(self) -> None:
+        from app.api.v1.task import run_task
+        from app.schemas.request import TaskConfig, TaskRun
+
+        background_tasks = MagicMock()
+        created_clients: dict[str, object] = {}
+
+        def callback_factory(**kwargs):
+            created_clients["callback"] = kwargs
+            return AsyncMock()
+
+        def user_input_factory(**kwargs):
+            created_clients["user_input"] = kwargs
+            return AsyncMock()
+
+        def computer_factory(**kwargs):
+            created_clients["computer"] = kwargs
+            return AsyncMock()
+
+        def memory_factory(**kwargs):
+            created_clients["memory"] = kwargs
+            return AsyncMock()
+
+        with (
+            patch("app.api.v1.task.CallbackClient", side_effect=callback_factory),
+            patch("app.api.v1.task.UserInputClient", side_effect=user_input_factory),
+            patch("app.api.v1.task.ComputerClient", side_effect=computer_factory),
+            patch("app.api.v1.task.MemoryClient", side_effect=memory_factory),
+            patch("app.api.v1.task.AgentExecutor"),
+            patch("app.api.v1.task.CallbackHook"),
+            patch("app.api.v1.task.BrowserScreenshotHook"),
+        ):
+            result = await run_task(
+                TaskRun(
+                    session_id="session-1",
+                    prompt="hello",
+                    callback_url="http://manager/api/v1/callback",
+                    callback_base_url="http://manager",
+                    callback_token=CALLBACK_TOKEN,
+                    config=TaskConfig(memory_enabled=True, browser_enabled=True),
+                ),
+                background_tasks,
+            )
+
+        self.assertEqual(result["status"], "accepted")
+        self.assertEqual(created_clients["callback"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["user_input"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["computer"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["memory"]["callback_token"], CALLBACK_TOKEN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/app/api/v1/agent_channel_artifacts.py
+++ b/executor_manager/app/api/v1/agent_channel_artifacts.py
@@ -1,13 +1,18 @@
 from typing import Any
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse, Response as FastAPIResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/agent-channel-artifacts", tags=["agent-channel-artifacts"])
+router = APIRouter(
+    prefix="/agent-channel-artifacts",
+    tags=["agent-channel-artifacts"],
+    dependencies=[Depends(require_callback_token)],
+)
 backend_client = BackendClient()
 
 

--- a/executor_manager/app/api/v1/agent_channel_runtime.py
+++ b/executor_manager/app/api/v1/agent_channel_runtime.py
@@ -1,14 +1,16 @@
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
 router = APIRouter(
     prefix="/agent-channel-runtime",
     tags=["agent-channel-runtime"],
+    dependencies=[Depends(require_callback_token)],
 )
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/agent_channel_tasks.py
+++ b/executor_manager/app/api/v1/agent_channel_tasks.py
@@ -1,12 +1,17 @@
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/agent-channel-tasks", tags=["agent-channel-tasks"])
+router = APIRouter(
+    prefix="/agent-channel-tasks",
+    tags=["agent-channel-tasks"],
+    dependencies=[Depends(require_callback_token)],
+)
 backend_client = BackendClient()
 
 

--- a/executor_manager/app/api/v1/callback.py
+++ b/executor_manager/app/api/v1/callback.py
@@ -1,15 +1,20 @@
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.callback import AgentCallbackRequest, CallbackReceiveResponse
 from app.schemas.response import Response, ResponseSchema
 from app.services.callback_service import CallbackService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/callback", tags=["callback"])
+router = APIRouter(
+    prefix="/callback",
+    tags=["callback"],
+    dependencies=[Depends(require_callback_token)],
+)
 callback_service = CallbackService()
 
 

--- a/executor_manager/app/api/v1/computer.py
+++ b/executor_manager/app/api/v1/computer.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter, File, Form, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 
+from app.core.deps import require_callback_token
 from app.schemas.computer import ComputerScreenshotUploadResponse
 from app.schemas.response import Response, ResponseSchema
 from app.services.computer_service import ComputerService
 
-router = APIRouter(prefix="/computer", tags=["computer"])
+router = APIRouter(
+    prefix="/computer",
+    tags=["computer"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 computer_service = ComputerService()
 

--- a/executor_manager/app/api/v1/executor.py
+++ b/executor_manager/app/api/v1/executor.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.task import (
     ContainerDeleteRequest,
@@ -10,7 +11,11 @@ from app.schemas.task import (
 )
 from app.scheduler.task_dispatcher import TaskDispatcher
 
-router = APIRouter(prefix="/executor", tags=["executor"])
+router = APIRouter(
+    prefix="/executor",
+    tags=["executor"],
+    dependencies=[Depends(require_internal_token)],
+)
 
 
 @router.post("/cancel", response_model=ResponseSchema[TaskCancelResult])

--- a/executor_manager/app/api/v1/memories.py
+++ b/executor_manager/app/api/v1/memories.py
@@ -1,8 +1,9 @@
 from typing import Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.memory import (
     MemoryCreateJobEnqueueResponse,
     MemoryCreateJobResponse,
@@ -13,7 +14,11 @@ from app.schemas.memory import (
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/memories", tags=["memories"])
+router = APIRouter(
+    prefix="/memories",
+    tags=["memories"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/schedules.py
+++ b/executor_manager/app/api/v1/schedules.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.core.settings import get_settings
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.schedule import (
@@ -17,7 +18,11 @@ from app.scheduler.pull_schedule_config import (
 from app.scheduler.pull_schedule_state import get_current_pull_schedule_config
 from app.scheduler.scheduler_config import scheduler
 
-router = APIRouter(prefix="/schedules", tags=["schedules"])
+router = APIRouter(
+    prefix="/schedules",
+    tags=["schedules"],
+    dependencies=[Depends(require_internal_token)],
+)
 
 
 def _build_job_info(job_id: str) -> ScheduleJobInfo | None:

--- a/executor_manager/app/api/v1/tasks.py
+++ b/executor_manager/app/api/v1/tasks.py
@@ -1,8 +1,9 @@
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.task import (
     SessionStatusResponse,
@@ -14,7 +15,11 @@ from app.services.task_service import TaskService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/tasks", tags=["tasks"])
+router = APIRouter(
+    prefix="/tasks",
+    tags=["tasks"],
+    dependencies=[Depends(require_internal_token)],
+)
 task_service = TaskService()
 
 

--- a/executor_manager/app/api/v1/user_input_requests.py
+++ b/executor_manager/app/api/v1/user_input_requests.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.user_input_request import (
     UserInputRequestCreateRequest,
@@ -8,7 +9,11 @@ from app.schemas.user_input_request import (
 )
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/user-input-requests", tags=["user-input-requests"])
+router = APIRouter(
+    prefix="/user-input-requests",
+    tags=["user-input-requests"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/workspace.py
+++ b/executor_manager/app/api/v1/workspace.py
@@ -1,14 +1,19 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.core.errors.error_codes import ErrorCode
 from app.core.errors.exceptions import AppException
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.workspace import FileNode
 from app.services.workspace_manager import WorkspaceManager
 
-router = APIRouter(prefix="/workspace", tags=["workspace"])
+router = APIRouter(
+    prefix="/workspace",
+    tags=["workspace"],
+    dependencies=[Depends(require_internal_token)],
+)
 workspace_manager = WorkspaceManager()
 
 

--- a/executor_manager/tests/test_agent_channel_artifacts_api.py
+++ b/executor_manager/tests/test_agent_channel_artifacts_api.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 from fastapi import FastAPI
@@ -9,7 +9,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_artifacts import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelArtifactsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_read_artifact_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -25,6 +37,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "artifact_id": "artifact-1",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -66,6 +79,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "logical_path": "Harness 工程核心指南.md",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(result.status_code, 404)
@@ -89,6 +103,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "artifact_id": "artifact-1",
                     "max_chars": 2000,
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -118,6 +133,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "artifact_id": "artifact-1",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_agent_channel_runtime_api.py
+++ b/executor_manager/tests/test_agent_channel_runtime_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -7,7 +7,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_runtime import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelRuntimeApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_read_messages_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -22,6 +34,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "message_ids": ["message-1"],
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -41,6 +54,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-runtime/agents/list",
                 json={"session_id": "session-1"},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -61,6 +75,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "agent_handle": "api",
                     "request_text": "Please review this.",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -87,6 +102,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "message_id": "message-1",
                     "emoji": "👍",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -110,6 +126,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "message_id": "message-1",
                     "emoji": "✅",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_agent_channel_tasks_api.py
+++ b/executor_manager/tests/test_agent_channel_tasks_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -7,7 +7,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_tasks import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelTasksApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_list_tasks_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -19,6 +31,7 @@ class AgentChannelTasksApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-tasks/list",
                 json={"session_id": "session-1", "status": "todo", "limit": 20},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -38,6 +51,7 @@ class AgentChannelTasksApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-tasks/read",
                 json={"session_id": "session-1", "task_id": "task-1"},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_control_plane_auth.py
+++ b/executor_manager/tests/test_control_plane_auth.py
@@ -1,0 +1,194 @@
+import unittest
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import executor, schedules, tasks, workspace
+
+
+INTERNAL_TOKEN = "internal-token"
+
+
+class ExecutorManagerControlPlaneAuthTests(unittest.TestCase):
+    def _app(self) -> FastAPI:
+        app = FastAPI()
+        app.include_router(workspace.router, prefix="/api/v1")
+        app.include_router(tasks.router, prefix="/api/v1")
+        app.include_router(executor.router, prefix="/api/v1")
+        app.include_router(schedules.router, prefix="/api/v1")
+
+        @app.get("/api/v1/health")
+        async def health() -> dict[str, str]:
+            return {"status": "healthy"}
+
+        return app
+
+    def _settings(self) -> MagicMock:
+        return MagicMock(
+            internal_api_token=INTERNAL_TOKEN,
+            schedule_config_path=None,
+        )
+
+    @contextmanager
+    def _with_common_patches(self) -> Iterator[None]:
+        task_response = SimpleNamespace(
+            model_dump=lambda: {
+                "task_id": "task-1",
+                "session_id": "session-1",
+                "status": "scheduled",
+            }
+        )
+        pool = MagicMock()
+        pool.delete_container = AsyncMock()
+        pool.get_container_stats.return_value = {
+            "total_active": 0,
+            "persistent_containers": 0,
+            "ephemeral_containers": 0,
+            "containers": [],
+        }
+        schedule_config = SimpleNamespace(enabled=True, rules=[])
+        patchers = [
+            patch("app.core.deps.get_settings", return_value=self._settings()),
+            patch(
+                "app.api.v1.workspace.workspace_manager.list_workspace_files",
+                return_value=[],
+            ),
+            patch(
+                "app.api.v1.workspace.workspace_manager.delete_workspace",
+                return_value=True,
+            ),
+            patch(
+                "app.api.v1.tasks.task_service.create_task",
+                new=AsyncMock(return_value=task_response),
+            ),
+            patch(
+                "app.api.v1.executor.TaskDispatcher.get_container_pool",
+                return_value=pool,
+            ),
+            patch(
+                "app.api.v1.schedules.get_current_pull_schedule_config",
+                return_value=schedule_config,
+            ),
+        ]
+        with ExitStack() as stack:
+            tmp_dir = stack.enter_context(TemporaryDirectory())
+            preview_file = Path(tmp_dir) / "secret.txt"
+            preview_file.write_text("secret", encoding="utf-8")
+            stack.enter_context(
+                patch(
+                    "app.api.v1.workspace.workspace_manager.resolve_workspace_file",
+                    return_value=preview_file,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "app.api.v1.workspace.workspace_manager.archive_workspace",
+                    return_value=str(preview_file),
+                )
+            )
+            for patcher in patchers:
+                stack.enter_context(patcher)
+            yield
+
+    def test_control_plane_routes_reject_missing_internal_token(self) -> None:
+        client = TestClient(self._app())
+        requests = [
+            (
+                "GET",
+                "/api/v1/workspace/file/victim/session-1?path=secret.txt",
+                None,
+            ),
+            ("GET", "/api/v1/workspace/files/victim/session-1", None),
+            ("POST", "/api/v1/workspace/archive/victim/session-1", None),
+            ("DELETE", "/api/v1/workspace/victim/session-1", None),
+            (
+                "POST",
+                "/api/v1/tasks",
+                {
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+            ),
+            ("POST", "/api/v1/executor/delete", {"container_id": "container-1"}),
+            ("GET", "/api/v1/executor/load", None),
+            ("GET", "/api/v1/schedules", None),
+        ]
+
+        with self._with_common_patches():
+            for method, path, body in requests:
+                with self.subTest(path=path):
+                    response = client.request(method, path, json=body)
+                    self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_reject_wrong_internal_token(self) -> None:
+        client = TestClient(self._app())
+
+        with self._with_common_patches():
+            response = client.get(
+                "/api/v1/workspace/files/victim/session-1",
+                headers={"X-Internal-Token": "wrong-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_reject_callback_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"Authorization": "Bearer callback-token"}
+
+        with self._with_common_patches():
+            response = client.post(
+                "/api/v1/tasks",
+                json={
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_accept_valid_internal_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"X-Internal-Token": INTERNAL_TOKEN}
+
+        with self._with_common_patches():
+            workspace_response = client.get(
+                "/api/v1/workspace/files/victim/session-1",
+                headers=headers,
+            )
+            task_response = client.post(
+                "/api/v1/tasks",
+                json={
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+                headers=headers,
+            )
+            executor_response = client.get("/api/v1/executor/load", headers=headers)
+            schedules_response = client.get("/api/v1/schedules", headers=headers)
+
+        self.assertEqual(workspace_response.status_code, 200)
+        self.assertEqual(task_response.status_code, 200)
+        self.assertEqual(executor_response.status_code, 200)
+        self.assertEqual(schedules_response.status_code, 200)
+
+    def test_health_route_stays_public(self) -> None:
+        response = TestClient(self._app()).get("/api/v1/health")
+
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/tests/test_executor_proxy_auth.py
+++ b/executor_manager/tests/test_executor_proxy_auth.py
@@ -1,0 +1,234 @@
+import unittest
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import (
+    agent_channel_artifacts,
+    agent_channel_runtime,
+    agent_channel_tasks,
+    callback,
+    computer,
+    memories,
+    user_input_requests,
+)
+from app.schemas.callback import CallbackReceiveResponse, CallbackStatus
+from app.schemas.computer import ComputerScreenshotUploadResponse
+
+
+CALLBACK_TOKEN = "callback-token"
+
+
+class ExecutorManagerProxyAuthTests(unittest.TestCase):
+    def _app(self) -> FastAPI:
+        app = FastAPI()
+        app.include_router(callback.router, prefix="/api/v1")
+        app.include_router(computer.router, prefix="/api/v1")
+        app.include_router(memories.router, prefix="/api/v1")
+        app.include_router(agent_channel_runtime.router, prefix="/api/v1")
+        app.include_router(agent_channel_artifacts.router, prefix="/api/v1")
+        app.include_router(agent_channel_tasks.router, prefix="/api/v1")
+        app.include_router(user_input_requests.router, prefix="/api/v1")
+        return app
+
+    def _settings(self) -> MagicMock:
+        return MagicMock(callback_token=CALLBACK_TOKEN)
+
+    def _user_input_payload(self) -> dict[str, object]:
+        now = datetime.now(timezone.utc).isoformat()
+        return {
+            "id": "request-1",
+            "session_id": "session-1",
+            "tool_name": "ask_user",
+            "tool_input": {},
+            "status": "pending",
+            "answers": None,
+            "expires_at": now,
+            "answered_at": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    @contextmanager
+    def _with_common_patches(self) -> Iterator[None]:
+        callback_response = CallbackReceiveResponse(
+            status="received",
+            session_id="session-1",
+            callback_status=CallbackStatus.RUNNING,
+            progress=10,
+        )
+        screenshot_response = ComputerScreenshotUploadResponse(
+            session_id="session-1",
+            run_id=None,
+            tool_use_id="tool-1",
+            key="screenshots/session-1/tool-1.png",
+            content_type="image/png",
+            size_bytes=4,
+        )
+        patchers = [
+            patch("app.core.deps.get_settings", return_value=self._settings()),
+            patch(
+                "app.api.v1.callback.callback_service.process_callback",
+                new=AsyncMock(return_value=callback_response),
+            ),
+            patch(
+                "app.api.v1.computer.computer_service.upload_browser_screenshot",
+                return_value=screenshot_response,
+            ),
+            patch(
+                "app.api.v1.memories.backend_client.create_memory",
+                new=AsyncMock(return_value={"job_id": "job-1", "status": "queued"}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_runtime."
+                "backend_client.read_agent_channel_messages",
+                new=AsyncMock(return_value={"messages": []}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_artifacts."
+                "backend_client.list_agent_channel_artifacts",
+                new=AsyncMock(return_value={"artifacts": []}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_tasks.backend_client.list_agent_channel_tasks",
+                new=AsyncMock(return_value={"tasks": []}),
+            ),
+            patch(
+                "app.api.v1.user_input_requests."
+                "backend_client.create_user_input_request",
+                new=AsyncMock(return_value=self._user_input_payload()),
+            ),
+        ]
+        with ExitStack() as stack:
+            for patcher in patchers:
+                stack.enter_context(patcher)
+            yield
+
+    def test_proxy_routes_reject_missing_callback_token(self) -> None:
+        client = TestClient(self._app())
+        requests = [
+            (
+                "POST",
+                "/api/v1/callback",
+                {
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/computer/screenshots",
+                {
+                    "data": {
+                        "session_id": "session-1",
+                        "tool_use_id": "tool-1",
+                    },
+                    "files": {"file": ("screenshot.png", b"data", "image/png")},
+                },
+                "multipart",
+            ),
+            (
+                "POST",
+                "/api/v1/memories",
+                {
+                    "session_id": "session-1",
+                    "messages": [{"role": "user", "content": "remember this"}],
+                },
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-runtime/messages/read",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-artifacts/list",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-tasks/list",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/user-input-requests",
+                {
+                    "session_id": "session-1",
+                    "tool_name": "ask_user",
+                    "tool_input": {},
+                },
+                None,
+            ),
+        ]
+
+        with self._with_common_patches():
+            for method, path, body, mode in requests:
+                with self.subTest(path=path):
+                    if mode == "multipart":
+                        response = client.request(method, path, **body)
+                    else:
+                        response = client.request(method, path, json=body)
+                    self.assertEqual(response.status_code, 403)
+
+    def test_proxy_routes_reject_internal_token_as_callback_token(self) -> None:
+        client = TestClient(self._app())
+
+        with self._with_common_patches():
+            response = client.post(
+                "/api/v1/callback",
+                json={
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                headers={"Authorization": "Bearer internal-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_proxy_routes_accept_valid_callback_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+        with self._with_common_patches():
+            callback_response = client.post(
+                "/api/v1/callback",
+                json={
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                headers=headers,
+            )
+            memory_response = client.post(
+                "/api/v1/memories",
+                json={
+                    "session_id": "session-1",
+                    "messages": [{"role": "user", "content": "remember this"}],
+                },
+                headers=headers,
+            )
+            channel_response = client.post(
+                "/api/v1/agent-channel-runtime/messages/read",
+                json={"session_id": "session-1"},
+                headers=headers,
+            )
+
+        self.assertEqual(callback_response.status_code, 200)
+        self.assertEqual(memory_response.status_code, 200)
+        self.assertEqual(channel_response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/tests/test_executor_proxy_auth.py
+++ b/executor_manager/tests/test_executor_proxy_auth.py
@@ -123,18 +123,6 @@ class ExecutorManagerProxyAuthTests(unittest.TestCase):
             ),
             (
                 "POST",
-                "/api/v1/computer/screenshots",
-                {
-                    "data": {
-                        "session_id": "session-1",
-                        "tool_use_id": "tool-1",
-                    },
-                    "files": {"file": ("screenshot.png", b"data", "image/png")},
-                },
-                "multipart",
-            ),
-            (
-                "POST",
                 "/api/v1/memories",
                 {
                     "session_id": "session-1",
@@ -175,11 +163,19 @@ class ExecutorManagerProxyAuthTests(unittest.TestCase):
         with self._with_common_patches():
             for method, path, body, mode in requests:
                 with self.subTest(path=path):
-                    if mode == "multipart":
-                        response = client.request(method, path, **body)
-                    else:
-                        response = client.request(method, path, json=body)
+                    response = client.request(method, path, json=body)
                     self.assertEqual(response.status_code, 403)
+            with self.subTest(path="/api/v1/computer/screenshots"):
+                response = client.request(
+                    "POST",
+                    "/api/v1/computer/screenshots",
+                    data={
+                        "session_id": "session-1",
+                        "tool_use_id": "tool-1",
+                    },
+                    files={"file": ("screenshot.png", b"data", "image/png")},
+                )
+                self.assertEqual(response.status_code, 403)
 
     def test_proxy_routes_reject_internal_token_as_callback_token(self) -> None:
         client = TestClient(self._app())

--- a/specs/active/33-executor-manager-workspace-authorization-hardening-plan.md
+++ b/specs/active/33-executor-manager-workspace-authorization-hardening-plan.md
@@ -1,0 +1,512 @@
+# Executor Manager API authentication hardening plan
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **创建日期** | 2026-06-11 |
+| **预期改动范围** | executor_manager API auth dependencies / backend EM clients / executor callback clients / tests / deployment notes |
+| **改动类型** | fix / security-hardening |
+| **优先级** | P0 |
+| **状态** | implemented |
+| **关联 issue** | `poco-ai/poco-claw#133` |
+| **关联 constitution** | `specs/constitution/2026-06-11-executor-manager-workspace-authorization.md` |
+
+## 实施阶段
+
+- [x] Phase 0: 路由盘点与失败测试
+- [x] Phase 1: 内部控制面接口补 `X-Internal-Token`
+- [x] Phase 2: Executor 回传/工具代理接口补 callback token
+- [x] Phase 3: 用户态功能和部署边界回归
+- [x] Phase 4: 验证、文档回写和后续加固记录
+
+---
+
+## 背景
+
+### 问题陈述
+
+`poco-ai/poco-claw#133` 报告的是 Executor Manager 的 `/api/v1/workspace/*` 没有鉴权，导致调用方可以通过 URL 中的 `user_id/session_id/path` 访问别人的执行 workspace。
+
+复查 EM 路由后，问题不只是一条 workspace file route。当前 EM 中只有少数接口已经有 token：
+
+- `/api/v1/internal/runs/notify` 已有 `X-Internal-Token`。
+- `/api/v1/skills/submit` 已有 callback token。
+
+其余多组接口在 HTTP 层没有 token。为了避免只补 issue PoC 而留下同类裸控制面，本计划按调用方分两步补齐：
+
+1. Backend/internal service 调 EM 的控制面接口使用 `X-Internal-Token`。
+2. Executor container 调 EM 的回传/工具代理接口使用 callback token。
+
+### 目标
+
+- `/api/v1/workspace/*` 直接无 token 访问返回 `403`。
+- `/api/v1/tasks`、`/api/v1/executor/*`、`/api/v1/schedules` 只有带 `X-Internal-Token` 的内部调用可以访问。
+- `/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories`、`/api/v1/agent-channel-*`、`/api/v1/user-input-requests` 只有带 callback token 的 executor 可以访问。
+- Backend 用户态 `/sessions/{session_id}/workspace/*`、`/runs/{run_id}/workspace/*` 体验不变。
+- 不把 `INTERNAL_API_TOKEN` 暴露给 executor container。
+- 不把 callback token 授予控制面能力。
+
+### 非目标
+
+- 不在 v1 引入 session-scoped workspace capability。
+- 不重做 Backend 用户态 session/run 鉴权。
+- 不改变 workspace export manifest 格式。
+- 不改变 share link、share to channel、channel artifacts 的产品语义。
+- 不在本轮解决多 EM 部署下的 token rotation/revocation。
+
+---
+
+## Phase 0: 路由盘点与失败测试
+
+### 目标
+
+先把当前裸接口和预期鉴权方式固定下来，避免实现时漏掉调用方同步。
+
+### 任务清单
+
+#### 0.1 固定 EM 路由鉴权矩阵
+
+**描述：** 在测试或文档注释中固定以下分类，作为实现检查表。
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/__init__.py`
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+- `executor_manager/app/api/v1/skills_upload.py`
+- `executor_manager/app/api/v1/internal_runs.py`
+
+**验收标准：**
+
+- [x] health/root route 明确保持无 token。
+- [x] `/internal/runs/notify` 明确保持 `X-Internal-Token`。
+- [x] `/skills/submit` 明确保持 callback token。
+- [x] workspace/tasks/executor/schedules 明确归类为 internal control plane。
+- [x] callback/computer/memories/agent-channel/user-input 明确归类为 executor callback/tool proxy。
+
+#### 0.2 增加 control plane 鉴权失败测试
+
+**描述：** 新增或扩展 EM API auth 测试，先证明无 token 访问会失败。
+
+**涉及文件：**
+
+- 新增 `executor_manager/tests/test_control_plane_auth.py`
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+
+**建议用例：**
+
+- `GET /api/v1/workspace/file/victim/{session}?path=secret.txt` without token returns `403`
+- `GET /api/v1/workspace/files/victim/{session}` without token returns `403`
+- `POST /api/v1/workspace/archive/victim/{session}` without token returns `403`
+- `DELETE /api/v1/workspace/victim/{session}` without token returns `403`
+- `POST /api/v1/tasks` without token returns `403`
+- `POST /api/v1/executor/delete` without token returns `403`
+- `GET /api/v1/executor/load` without token returns `403`
+- `GET /api/v1/schedules` without token returns `403`
+- `GET /api/v1/health` still returns `200`
+
+**验收标准：**
+
+- [x] 当前未修复代码下这些测试能暴露缺口。
+- [x] 修复后全部返回预期状态。
+- [x] 测试不依赖 Docker daemon 或真实 object storage。
+
+#### 0.3 增加 executor proxy 鉴权失败测试
+
+**描述：** 覆盖 executor 回传/工具代理接口，未带 callback token 应返回 `403`。
+
+**涉及文件：**
+
+- 新增 `executor_manager/tests/test_executor_proxy_auth.py`
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+
+**建议用例：**
+
+- `POST /api/v1/callback` without bearer token returns `403`
+- `POST /api/v1/computer/screenshots` without bearer token returns `403`
+- `POST /api/v1/memories` without bearer token returns `403`
+- `POST /api/v1/agent-channel-runtime/messages/read` without bearer token returns `403`
+- `POST /api/v1/agent-channel-artifacts/list` without bearer token returns `403`
+- `POST /api/v1/agent-channel-tasks/list` without bearer token returns `403`
+- `POST /api/v1/user-input-requests` without bearer token returns `403`
+- same endpoints with valid callback token preserve existing behavior through mocked services
+
+**验收标准：**
+
+- [x] 无 token 请求全部拒绝。
+- [x] 带合法 callback token 请求不破坏现有 mock/service 调用。
+- [x] `/api/v1/skills/submit` 继续通过现有 callback token 测试。
+
+---
+
+## Phase 1: 内部控制面接口补 `X-Internal-Token`
+
+### 目标
+
+把 Backend/internal service 调用的 EM 控制面接口收成 internal-only。
+
+### 任务清单
+
+#### 1.1 给 control plane routers 加 `require_internal_token`
+
+**描述：** 给以下 router 或 route 增加 `Depends(require_internal_token)`：
+
+- `/api/v1/workspace/*`
+- `/api/v1/tasks`
+- `/api/v1/executor/*`
+- `/api/v1/schedules`
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+- `executor_manager/app/core/deps.py`
+- `executor_manager/tests/test_control_plane_auth.py`
+
+**验收标准：**
+
+- [x] 无 `X-Internal-Token` 时返回 `403`。
+- [x] 错误 `X-Internal-Token` 时返回 `403`。
+- [x] 正确 `X-Internal-Token` 时保持原有功能。
+- [x] health/root route 不受影响。
+
+#### 1.2 更新 Backend 调 EM 的 control plane client
+
+**描述：** Backend 调 EM control plane 时必须带 `X-Internal-Token`。
+
+**涉及文件：**
+
+- `backend/app/services/executor_manager_client.py`
+- `backend/app/api/v1/schedules.py`
+- 可能涉及创建任务的 Backend service/client 调用路径
+- `backend/tests/test_executor_manager_notify_service.py`
+- 新增或扩展 `backend/tests/test_executor_manager_client.py`
+
+**验收标准：**
+
+- [x] `ExecutorManagerClient.delete_container()` 请求 `/api/v1/executor/delete` 时带 `X-Internal-Token`。
+- [x] Backend schedules proxy 请求 `/api/v1/schedules` 时带 `X-Internal-Token`。
+- [x] 如果 Backend 仍直接请求 `/api/v1/tasks`，该请求也带 `X-Internal-Token`。
+- [x] 既有 `/api/v1/internal/runs/notify` 调用继续带 `X-Internal-Token`。
+
+#### 1.3 保留 workspace 产品入口在 Backend
+
+**描述：** 不把前端文件浏览改到 EM；只加固 EM 底层接口。
+
+**涉及文件：**
+
+- `backend/app/api/v1/sessions.py`
+- `backend/app/api/v1/runs.py`
+- `frontend/features/chat/api/chat-api.ts`
+- `frontend/services/api-client.ts`
+
+**验收标准：**
+
+- [x] Frontend `chatService.getFiles()` 继续走 `/sessions/{session_id}/workspace/files`。
+- [x] Frontend `chatService.getRunFiles()` 继续走 `/runs/{run_id}/workspace/files`。
+- [x] Backend session/run workspace owner check 保持在读取 manifest 和生成 presigned URL 之前。
+
+---
+
+## Phase 2: Executor 回传/工具代理接口补 callback token
+
+### 目标
+
+把 executor container 调 EM 的回传和工具代理接口收成 callback-token-only，同时同步 executor client，避免执行链路被打断。
+
+### 任务清单
+
+#### 2.1 给 executor proxy routers 加 `require_callback_token`
+
+**描述：** 给以下 router 或 route 增加 `Depends(require_callback_token)`：
+
+- `/api/v1/callback`
+- `/api/v1/computer/screenshots`
+- `/api/v1/memories`
+- `/api/v1/agent-channel-runtime/*`
+- `/api/v1/agent-channel-artifacts/*`
+- `/api/v1/agent-channel-tasks/*`
+- `/api/v1/user-input-requests`
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+- `executor_manager/app/core/deps.py`
+- `executor_manager/tests/test_executor_proxy_auth.py`
+
+**验收标准：**
+
+- [x] 无 `Authorization: Bearer <callback_token>` 时返回 `403`。
+- [x] 错误 callback token 时返回 `403`。
+- [x] 正确 callback token 时保持原有转发和上传行为。
+- [x] `/api/v1/skills/submit` 保持现有 callback token 鉴权，不重复实现。
+
+#### 2.2 Executor clients 统一带 callback token
+
+**描述：** executor 侧所有调 EM 的回传/工具 client 都要带 `Authorization: Bearer <callback_token>`。
+
+**涉及文件：**
+
+- `executor/app/api/v1/task.py`
+- `executor/app/core/callback.py`
+- `executor/app/core/computer.py`
+- `executor/app/core/memory.py`
+- `executor/app/core/channel_runtime.py`
+- `executor/app/core/user_input.py`
+- `executor/tests/test_channel_runtime_tools.py`
+- 新增或扩展 executor client auth tests
+
+**验收标准：**
+
+- [x] `CallbackClient` 初始化时接收 callback token，并在 `/api/v1/callback` 请求中发送 Bearer token。
+- [x] `ComputerClient` 初始化时接收 callback token，并在 screenshot upload 请求中发送 Bearer token。
+- [x] `MemoryClient` 初始化时接收 callback token，并在 memory proxy 请求中发送 Bearer token。
+- [x] `ChannelRuntimeClient` 初始化时接收 callback token，并在 runtime/artifact/task proxy 请求中发送 Bearer token。
+- [x] `UserInputClient` 初始化时接收 callback token，并在 user input 请求中发送 Bearer token。
+- [x] `executor/app/api/v1/task.py` 从 `TaskRun.callback_token` 传给上述 client。
+
+#### 2.3 保持 callback token 不进入控制面
+
+**描述：** callback token 只能用于 executor 回传/工具代理接口，不能用于 `/tasks`、`/executor/*`、`/workspace/*`、`/schedules`。
+
+**涉及文件：**
+
+- `executor_manager/tests/test_control_plane_auth.py`
+- `executor_manager/tests/test_executor_proxy_auth.py`
+
+**验收标准：**
+
+- [x] 用 callback token 调 `/api/v1/workspace/stats` 返回 `403`。
+- [x] 用 callback token 调 `/api/v1/tasks` 返回 `403`。
+- [x] 用 callback token 调 `/api/v1/executor/delete` 返回 `403`。
+- [x] 用 internal token 调 `/api/v1/callback` 返回 `403`，除非它恰好等于 callback token。
+
+---
+
+## Phase 3: 用户态功能和部署边界回归
+
+### 目标
+
+确认安全加固不影响正常用户体验，并记录部署边界。
+
+### 任务清单
+
+#### 3.1 Backend 用户态 workspace 回归
+
+**涉及文件：**
+
+- `backend/app/api/v1/sessions.py`
+- `backend/app/api/v1/runs.py`
+- `backend/tests/test_session_share_service.py`
+- 新增或扩展 `backend/tests/test_session_workspace_authorization.py`
+
+**验收标准：**
+
+- [x] owner 可以继续读取 session workspace files。
+- [x] owner 可以继续读取 run workspace files。
+- [x] non-owner 继续返回 `403`。
+- [x] share link public response 不暴露 `workspace_manifest_key`、`workspace_files_prefix`、source session id 或 owner user id。
+
+#### 3.2 Frontend API boundary 回归
+
+**涉及文件：**
+
+- `frontend/features/chat/api/chat-api.ts`
+- `frontend/features/chat/components/execution/file-panel/hooks/use-artifacts.ts`
+- `frontend/services/api-client.ts`
+
+**验收标准：**
+
+- [x] Artifacts panel 仍通过 Backend session/run API 拉文件。
+- [x] Frontend 代码中没有 direct EM `/api/v1/workspace/*` 调用。
+- [x] `pnpm lint` 和 `pnpm build` 通过，或记录明确阻塞。
+
+#### 3.3 部署文档更新
+
+**涉及文件：**
+
+- `README.md` 或部署相关文档
+- `docker-compose.yml`
+- `docker-compose.r2.yml`
+- `.env.example` 类文件，如存在
+
+**验收标准：**
+
+- [x] 文档说明 EM 8001 不应公网暴露。
+- [x] 文档说明 `INTERNAL_API_TOKEN` 供 Backend/internal service 调 EM 控制面。
+- [x] 文档说明 `CALLBACK_TOKEN` 供 executor container 调 EM 回传/工具代理接口。
+- [x] 不把真实 token 写入文档。
+
+---
+
+## Phase 4: 验证、文档回写和后续加固记录
+
+### 目标
+
+跑 targeted tests 和最小静态检查，并把实际结果回写到 spec。
+
+### 任务清单
+
+#### 4.1 Executor Manager 验证
+
+**验证命令：**
+
+```bash
+cd executor_manager
+uv run python -m unittest tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m py_compile app/api/v1/workspace.py app/api/v1/tasks.py app/api/v1/executor.py app/api/v1/schedules.py app/api/v1/callback.py app/api/v1/computer.py app/api/v1/memories.py app/api/v1/agent_channel_runtime.py app/api/v1/agent_channel_artifacts.py app/api/v1/agent_channel_tasks.py app/api/v1/user_input_requests.py app/core/deps.py
+uv run ruff check app/api/v1/workspace.py app/api/v1/tasks.py app/api/v1/executor.py app/api/v1/schedules.py app/api/v1/callback.py app/api/v1/computer.py app/api/v1/memories.py app/api/v1/agent_channel_runtime.py app/api/v1/agent_channel_artifacts.py app/api/v1/agent_channel_tasks.py app/api/v1/user_input_requests.py tests/test_control_plane_auth.py tests/test_executor_proxy_auth.py
+```
+
+**验收标准：**
+
+- [x] workspace PoC 无 token 返回 `403`。
+- [x] control plane 只有 internal token 可访问。
+- [x] executor proxy 只有 callback token 可访问。
+- [x] health/root 无 token 可访问。
+
+#### 4.2 Backend / Executor 验证
+
+**验证命令：**
+
+```bash
+cd backend
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy tests.test_executor_manager_notify_service tests.test_agent_assignment_service
+uv run python -m py_compile app/services/executor_manager_client.py app/api/v1/schedules.py app/api/v1/sessions.py app/api/v1/runs.py
+
+cd ../executor
+uv run python -m unittest tests.test_manager_auth_clients tests.test_channel_runtime_tools tests.test_engine_channel_artifact_tools tests.test_engine_channel_reaction_tools tests.test_engine_channel_task_hint tests.test_engine_channel_runtime_hint tests.test_engine_persistent_state_hint
+uv run python -m py_compile app/api/v1/task.py app/core/callback.py app/core/computer.py app/core/memory.py app/core/channel_runtime.py app/core/user_input.py
+```
+
+**验收标准：**
+
+- [x] Backend 调 EM control plane 带 internal token。
+- [x] Executor 调 EM callback/tool proxy 带 callback token。
+- [x] 现有 channel runtime tools 测试通过。
+- [x] session/run workspace 用户态回归通过。
+
+#### 4.3 Frontend 验证
+
+**验证命令：**
+
+```bash
+cd frontend
+rg -n "executor_manager|/api/v1/workspace|workspace/file/" app features services
+```
+
+**验收标准：**
+
+- [x] Frontend 没有 direct EM workspace 调用。
+- [x] 本次未修改 frontend；执行边界扫描即可，未跑 `pnpm lint` / `pnpm build`。
+
+#### 4.4 Spec 回写
+
+**涉及文件：**
+
+- `specs/active/33-executor-manager-workspace-authorization-hardening-plan.md`
+- `specs/constitution/2026-06-11-executor-manager-workspace-authorization.md`
+
+**验收标准：**
+
+- [x] 完成 phase 标记为 `[x]`。
+- [x] 写入实际验证命令和结果。
+- [x] 如果实现中改变接口分类，更新 constitution 的 EM API 分类表。
+- [x] 记录后续更细粒度加固项：session-scoped capability、token rotation、生产默认 token fail-fast。
+
+---
+
+## 实施记录
+
+### 2026-06-11
+
+**实际落地：**
+
+- `workspace/tasks/executor/schedules` 已统一挂 `require_internal_token`。
+- `callback/computer/memories/agent-channel-runtime/agent-channel-artifacts/agent-channel-tasks/user-input-requests` 已统一挂 `require_callback_token`。
+- Backend `ExecutorManagerClient.delete_container()` 和 schedules proxy 已补 `X-Internal-Token`。
+- Executor `CallbackClient`、`ComputerClient`、`MemoryClient`、`ChannelRuntimeClient`、`UserInputClient` 已接收并发送 callback token。
+- `executor/app/api/v1/task.py` 已把 `TaskRun.callback_token` 传给上述 executor client。
+- Frontend 文件浏览仍通过 Backend `/sessions/{session_id}/workspace/files` 和 `/runs/{run_id}/workspace/files`。
+
+**已执行验证：**
+
+```bash
+cd executor_manager
+uv run python -m unittest tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m unittest tests.test_agent_channel_runtime_api tests.test_agent_channel_artifacts_api tests.test_agent_channel_tasks_api tests.test_internal_runs_notify tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m unittest discover -s tests
+
+cd ../executor
+uv run python -m unittest tests.test_manager_auth_clients
+uv run python -m unittest tests.test_manager_auth_clients tests.test_channel_runtime_tools tests.test_engine_channel_artifact_tools tests.test_engine_channel_reaction_tools tests.test_engine_channel_task_hint tests.test_engine_channel_runtime_hint tests.test_engine_persistent_state_hint
+uv run python -m unittest discover -s tests
+
+cd ../backend
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy tests.test_executor_manager_notify_service tests.test_agent_assignment_service
+
+cd ..
+rg -n "executor_manager|/api/v1/workspace|workspace/file/|workspace/files|sessionWorkspaceFiles|runWorkspaceFiles" frontend/app frontend/features frontend/services backend/app/api/v1/sessions.py backend/app/api/v1/runs.py
+```
+
+**验证结果：**
+
+- 上述 `unittest` 命令均通过。
+- `executor_manager` 完整 unittest discover：41 tests passed。
+- `executor` 完整 unittest discover：45 tests passed。
+- Backend targeted unittest：8 tests passed。
+- `pytest` 当前未安装在各服务 venv 中，因此本轮按仓库现有 `unittest` 测试风格验证。
+- Frontend 未改代码；边界扫描确认没有 direct EM workspace 调用，仍走 Backend session/run workspace API。
+
+---
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+| --- | --- | --- |
+| 只给 EM route 加 token，忘记更新调用方 | Backend 或 executor 调用失败 | 每个 phase 都包含调用方同步和测试 |
+| 把 executor proxy 错套 `X-Internal-Token` | executor container 需要拿 internal token，扩大权限 | executor proxy 统一用 callback token |
+| 把 control plane 错套 callback token | executor token 可创建任务或删容器 | control plane 统一用 internal token，并测试 callback token 不可访问 |
+| EM 8001 仍公网暴露 | 攻击面仍大 | 代码 fail closed + 部署文档明确不公网暴露 |
+| 默认 token 未改 | token 等同公开 | 后续加固记录 production fail-fast，文档强调非默认 |
+
+---
+
+## 总结
+
+v1 修复不是“只修 workspace file”，也不是“所有 EM 接口用同一个 token”。正确边界是：
+
+- Backend/internal service 调 EM 控制面：`X-Internal-Token`。
+- Executor container 调 EM 回传/工具代理：callback token。
+- Frontend 继续只调 Backend 用户态 API。
+- Health/root 保持无 token。
+
+这能直接关闭 issue #133 的 workspace 裸接口风险，也把 EM 其他裸接口纳入同一轮可审核的加固计划。

--- a/specs/constitution/2026-06-11-executor-manager-workspace-authorization.md
+++ b/specs/constitution/2026-06-11-executor-manager-workspace-authorization.md
@@ -1,0 +1,171 @@
+# Executor Manager API 鉴权边界决策
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **决策日期** | 2026-06-11 |
+| **关联 spec** | `specs/active/33-executor-manager-workspace-authorization-hardening-plan.md` |
+| **关联 issue** | `poco-ai/poco-claw#133` |
+
+## 决策摘要
+
+`poco-ai/poco-claw#133` 直接暴露的问题是 Executor Manager 的 `/api/v1/workspace/*` 接口没有鉴权，调用方只要能访问 EM，就可以把 URL 里的 `user_id` 换成别人并读取、列举、归档或删除对应执行 workspace。
+
+进一步检查后，EM 还有一些非 health 接口也没有 HTTP 层 token。最终决定是：**EM 除健康检查外，所有接口都必须明确属于某一类受信调用方，并使用对应 token**。
+
+第一类是 Backend 或内部服务调用 EM 的控制面接口，统一使用 `X-Internal-Token`。第二类是 executor container 回传进度、截图、memory、channel tool 调用等执行器回传/工具代理接口，统一使用 `Authorization: Bearer <callback_token>`。Backend 面向用户的 `/sessions/{session_id}/workspace/*` 和 `/runs/{run_id}/workspace/*` 接口保持现状，不迁移到 EM，也不改变前端 Artifacts 体验。
+
+## 背景
+
+当前 Poco 的服务边界大致是：
+
+- Frontend 调 Backend 用户态 API；
+- Backend 用用户登录态做业务鉴权，并用 `X-Internal-Token` 调内部接口；
+- Executor Manager 负责调度、容器管理、workspace 管理，并把 executor container 的回调转发给 Backend；
+- Executor container 通过 EM 提交 callback、截图、memory 和 channel runtime tool 请求。
+
+Backend 用户态 workspace API 本身已有 owner check。例如 `/api/v1/sessions/{session_id}/workspace/files` 会先解析当前用户，再校验 `AgentSession.user_id`。所以 issue #133 的核心不是 Backend 用户接口，而是 EM 的 live workspace 接口。
+
+EM 当前存在三种接口状态：
+
+- 已经走 `X-Internal-Token`：例如 `/api/v1/internal/runs/notify`。
+- 已经走 callback token：例如 `/api/v1/skills/submit`。
+- 还没有 HTTP token：例如 `/api/v1/workspace/*`、`/api/v1/tasks`、`/api/v1/executor/*`、`/api/v1/schedules`、`/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories`、`/api/v1/agent-channel-*`、`/api/v1/user-input-requests`。
+
+由于 `docker-compose.yml` 默认把 EM `8001` 映射到宿主机端口，不能把“它理论上只给内部服务用”当成代码层面的安全保证。即使部署上应避免公网暴露，代码也应该做到 fail closed。
+
+## 用户叙事
+
+**Alice 是普通用户，在页面里查看 agent 产物。**
+
+1. Alice 打开 Artifacts 面板。
+2. Frontend 继续调用 Backend `/api/v1/sessions/{session_id}/workspace/files`。
+3. Backend 校验 Alice 是否拥有该 session，再返回文件树和预览 URL。
+4. Alice 的体验不变，不需要知道 EM 地址，也不能直接访问 EM workspace 文件。
+
+**Bob 是外部调用者，能打到 EM 端口。**
+
+1. Bob 请求 `/api/v1/workspace/file/alice/{session_id}?path=secrets.txt`。
+2. 因为请求没有 `X-Internal-Token`，EM 返回 `403`。
+3. Bob 即使知道 `user_id/session_id/path`，也不能绕过 Backend 用户态授权。
+
+**Backend 需要创建任务或删除容器。**
+
+1. Backend 调 `/api/v1/tasks` 或 `/api/v1/executor/delete`。
+2. 请求必须带 `X-Internal-Token`。
+3. EM 只接受与自身配置一致的内部 token。
+
+**Executor container 需要回传执行信息。**
+
+1. EM dispatch 任务时把 `callback_token` 传给 executor。
+2. Executor 调 `/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories` 或 `/api/v1/agent-channel-*` 时带 `Authorization: Bearer <callback_token>`。
+3. EM 只接受合法 callback token，再把请求转发给 Backend internal API。
+
+## 最终决策
+
+这次决策的核心是：**EM 不是用户态入口。EM 的非 health API 必须按调用方类型显式鉴权。**
+
+- **产品决策**：用户态文件浏览、archive 下载、share link、share to channel 的入口继续在 Backend；正常用户体验不变。
+- **技术决策**：内部控制面接口使用 `X-Internal-Token`，包括 `/workspace/*`、`/tasks`、`/executor/*`、`/schedules`。
+- **技术决策**：执行器回传/工具代理接口使用 `Authorization: Bearer <callback_token>`，包括 `/callback`、`/computer/screenshots`、`/memories`、`/agent-channel-*`、`/user-input-requests`。
+- **技术决策**：`/internal/runs/notify` 保持 `X-Internal-Token`；`/skills/submit` 保持 callback token。
+- **技术决策**：v1 不引入 session-scoped workspace capability。这个可以作为后续更细粒度加固，但不是当前 issue 的第一优先级。
+- **技术决策**：`user_id`、`session_id`、`path` 都只能作为业务参数，不能替代 token 鉴权。
+
+## 设计约束与不变量
+
+- EM 只保留 `/api/v1/health`、`/api/v1/` 这类健康/状态接口无 token；其他接口必须有 token。
+- Backend 调 EM 控制面时必须带 `X-Internal-Token`。
+- Executor 调 EM 回传/工具代理接口时必须带 callback token。
+- 不要把所有 EM 接口一刀切成 `X-Internal-Token`，否则 executor container 现有调用链会断。
+- 不要把所有 EM 接口一刀切成 callback token，控制面接口仍应只允许 Backend/internal service。
+- Frontend 不直接访问 EM。
+- Backend 用户态接口继续使用登录态和 session/run owner check。
+- `/api/v1/workspace/*` 即使加了 internal token，也不能把 URL 中的 `user_id` 当作用户身份；后续可继续收敛 legacy `{user_id}/{session_id}` 路径。
+- `INTERNAL_API_TOKEN` 和 `CALLBACK_TOKEN` 在生产环境不能使用默认值。
+
+## 技术设计与结构边界
+
+### EM API 分类
+
+| 接口 | 调用方 | 鉴权方式 | 说明 |
+| --- | --- | --- | --- |
+| `/api/v1/health`、`/api/v1/` | health check / service discovery | 无 token | 只返回服务状态 |
+| `/api/v1/internal/runs/notify` | Backend | `X-Internal-Token` | 已符合目标状态 |
+| `/api/v1/workspace/*` | Backend / internal admin | `X-Internal-Token` | issue #133 核心修复面 |
+| `/api/v1/tasks` | Backend | `X-Internal-Token` | 创建/查询任务，属于控制面 |
+| `/api/v1/executor/*` | Backend / internal admin | `X-Internal-Token` | cancel/delete/load，属于控制面 |
+| `/api/v1/schedules` | Backend | `X-Internal-Token` | 当前由 Backend proxy 给前端展示 |
+| `/api/v1/callback` | Executor container | callback token | agent 进度/状态回传 |
+| `/api/v1/computer/screenshots` | Executor container | callback token | 浏览器截图上传 |
+| `/api/v1/memories` | Executor container | callback token | memory tool proxy |
+| `/api/v1/agent-channel-*` | Executor container | callback token | channel runtime/artifact/task tool proxy |
+| `/api/v1/user-input-requests` | Executor container | callback token | user-input tool proxy |
+| `/api/v1/skills/submit` | Executor helper | callback token | 已符合 v1 目标状态 |
+
+### 内部控制面
+
+控制面接口统一依赖 `require_internal_token`。同时需要补齐调用方：
+
+- `backend/app/services/executor_manager_client.py` 调 `/api/v1/executor/delete` 时带 `X-Internal-Token`。
+- `backend/app/api/v1/schedules.py` proxy `/api/v1/schedules` 时带 `X-Internal-Token`。
+- 创建任务的 Backend 调用路径如果仍走 `/api/v1/tasks`，也必须带 `X-Internal-Token`。
+
+### Executor 回传和工具代理
+
+回传/工具代理接口统一依赖 `require_callback_token`。同时需要补齐 executor 侧 client：
+
+- `executor/app/core/callback.py` 的 `CallbackClient` 带 `Authorization: Bearer <callback_token>`。
+- `executor/app/core/computer.py` 的 `ComputerClient` 带 callback token。
+- `executor/app/core/memory.py` 的 `MemoryClient` 带 callback token。
+- `executor/app/core/channel_runtime.py` 的 `ChannelRuntimeClient` 带 callback token。
+- `executor/app/core/user_input.py` 的 `UserInputClient` 带 callback token。
+- `executor/app/api/v1/task.py` 在构造这些 client 时传入 `req.callback_token`。
+
+### Backend 用户态入口
+
+Backend 用户态接口不是本次问题的根源，保持现有职责：
+
+1. 从 cookie/bearer token 解析用户。
+2. 查 session/run。
+3. 校验 owner 或明确的协作权限。
+4. 授权通过后读取 workspace export manifest 或生成 presigned URL。
+
+### 数据流
+
+```mermaid
+flowchart TD
+    Frontend["Frontend"] -->|"auth cookie / bearer"| Backend["Backend user API"]
+    Backend -->|"X-Internal-Token"| EMControl["EM control plane: workspace/tasks/executor/schedules"]
+    EM["Executor Manager"] -->|"callback_token in task request"| Executor["Executor container"]
+    Executor -->|"Authorization: Bearer callback_token"| EMCallback["EM callback/tool proxy APIs"]
+    EMCallback -->|"X-Internal-Token"| BackendInternal["Backend internal APIs"]
+```
+
+## 备选方案简述
+
+- **只给 `/workspace/*` 加 token。**
+  能修 issue #133，但 EM 其他控制面和回传接口仍然裸露，后续还会有类似问题。
+
+- **所有 EM 接口都用 `X-Internal-Token`。**
+  不采用。Executor container 当前拿的是 callback token，回传/工具代理接口应该用 callback token，否则要把 internal token 暴露给 executor。
+
+- **所有 EM 接口都用 callback token。**
+  不采用。`/tasks`、`/executor/delete`、`/workspace/delete` 这类控制面能力不应该交给 executor token。
+
+- **直接做 session-scoped capability。**
+  暂不作为 v1。它更细，但会扩大实现范围；当前先统一两类既有 token，把裸接口关闭。
+
+## 约束与前提
+
+- `CALLBACK_TOKEN` 已经通过 EM dispatch 传给 executor，适合作为 executor -> EM 回传鉴权凭证。
+- `INTERNAL_API_TOKEN` 已经用于 Backend/EM 内部接口，适合作为 Backend -> EM 控制面鉴权凭证。
+- 生产部署仍应避免公网暴露 EM 8001；代码鉴权不是网络隔离的替代品。
+
+## 历史变更
+
+| 日期 | 变更内容 | 原因 |
+| --- | --- | --- |
+| 2026-06-11 | 初次记录 | 针对 `poco-ai/poco-claw#133` 和 EM 裸接口盘点，固定两类 token 的 API 鉴权边界 |
+| 2026-06-11 | 实现完成 | 按两类 token 边界落地 EM 路由鉴权、Backend internal header、Executor callback token header，并保留 Backend 用户态 workspace 入口 |


### PR DESCRIPTION
## 变更
- EM 控制面接口补 `X-Internal-Token`
- executor 回传/工具代理接口补 callback token
- 同步 Backend / Executor 调用方 header 与回归测试
- 补充鉴权边界 constitution 和实施 spec

## 验证
- `executor_manager`: unittest discover 41 tests passed
- `executor`: unittest discover 45 tests passed
- `backend`: targeted unittest 8 tests passed

Refs #133