### PR TITLE
feat: 支持普通聊天引用当前会话文件

### DIFF
--- a/COMMIT.md
+++ b/COMMIT.md
@@ -1,6 +1,6 @@
-fix(server-channel): name agent direct messages by handle
+fix(executor-manager): require tokens for manager APIs
 
-- Create agent direct-message channels with @handle names and handle-based slugs
-- Project existing agent DMs with current handles when listing channels
-- Keep newly opened DMs in local channel state before routing to the conversation
-- Cover agent DM naming and legacy projection behavior in backend tests
+- Protect EM control-plane routes with X-Internal-Token and executor proxy routes with callback tokens
+- Send internal headers from Backend EM clients and callback Bearer tokens from executor clients
+- Add auth regression coverage for EM routes, Backend callers, and executor manager clients
+- Record the token boundary decision and completed hardening plan

--- a/backend/app/api/v1/schedules.py
+++ b/backend/app/api/v1/schedules.py
@@ -21,7 +21,10 @@ async def get_schedules() -> JSONResponse:
     url = f"{settings.executor_manager_url}/api/v1/schedules"
 
     try:
-        headers = {"accept": "application/json"}
+        headers = {
+            "accept": "application/json",
+            "X-Internal-Token": settings.internal_api_token,
+        }
         request_id = get_request_id()
         if request_id:
             headers["X-Request-ID"] = request_id

--- a/backend/app/models/session_queue_item.py
+++ b/backend/app/models/session_queue_item.py
@@ -99,3 +99,13 @@ class AgentSessionQueueItem(Base, TimestampMixin):
             return []
         input_files = snapshot.get("input_files")
         return list(input_files) if isinstance(input_files, list) else []
+
+    @property
+    def file_references(self) -> list[dict[str, Any]]:
+        snapshot = self.run_config_snapshot
+        if not isinstance(snapshot, dict):
+            return []
+        references = snapshot.get("file_references")
+        if references is None:
+            references = snapshot.get("input_file_references")
+        return list(references) if isinstance(references, list) else []

--- a/backend/app/schemas/input_file.py
+++ b/backend/app/schemas/input_file.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class InputFile(BaseModel):
@@ -13,3 +13,53 @@ class InputFile(BaseModel):
     size: int | None = None
     content_type: str | None = None
     path: str | None = None
+
+
+class FileReferenceRange(BaseModel):
+    start: int = Field(ge=0)
+    end: int = Field(ge=0)
+
+
+class InputFileReferenceMetadata(BaseModel):
+    input_file_id: str | None = Field(default=None, alias="inputFileId")
+    size: int | None = None
+    content_type: str | None = Field(default=None, alias="contentType")
+    path: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+
+class InputFileReference(BaseModel):
+    id: str = Field(min_length=1)
+    kind: Literal["input_file"] = "input_file"
+    source: str = Field(min_length=1)
+    inserted_text: str = Field(min_length=1, alias="insertedText")
+    display_name: str = Field(min_length=1, alias="displayName")
+    range: FileReferenceRange | None = None
+    metadata: InputFileReferenceMetadata | None = None
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+
+class WorkspaceFileReferenceMetadata(BaseModel):
+    size: int | None = None
+    content_type: str | None = Field(default=None, alias="contentType")
+    source_kind: str | None = Field(default=None, alias="sourceKind")
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+
+class WorkspaceFileReference(BaseModel):
+    id: str = Field(min_length=1)
+    kind: Literal["workspace_file"] = "workspace_file"
+    session_id: str = Field(min_length=1, alias="sessionId")
+    path: str = Field(min_length=1)
+    inserted_text: str = Field(min_length=1, alias="insertedText")
+    display_name: str = Field(min_length=1, alias="displayName")
+    range: FileReferenceRange | None = None
+    metadata: WorkspaceFileReferenceMetadata | None = None
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+
+FileReference = InputFileReference | WorkspaceFileReference

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.schemas.agent_trigger import AgentTriggerEnvelope
 from app.schemas.callback import AgentCurrentState
 from app.schemas.filesystem import LocalMountConfig, FilesystemMode
-from app.schemas.input_file import InputFile
+from app.schemas.input_file import FileReference, InputFile
 from app.schemas.sub_agent import SubAgentModel
 
 
@@ -54,6 +54,8 @@ class TaskConfig(BaseModel):
     filesystem_mode: FilesystemMode = "sandbox"
     local_mounts: list[LocalMountConfig] = Field(default_factory=list)
     input_files: list[InputFile] = Field(default_factory=list)
+    file_references: list[FileReference] = Field(default_factory=list)
+    input_file_references: list[FileReference] = Field(default_factory=list)
 
 
 class SessionCreateRequest(BaseModel):

--- a/backend/app/schemas/session_queue_item.py
+++ b/backend/app/schemas/session_queue_item.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.schemas.input_file import InputFile
+from app.schemas.input_file import FileReference, InputFile
 
 
 class SessionQueueItemResponse(BaseModel):
@@ -16,6 +16,7 @@ class SessionQueueItemResponse(BaseModel):
     prompt: str
     permission_mode: str
     attachments: list[InputFile] = Field(default_factory=list)
+    file_references: list[FileReference] = Field(default_factory=list)
     client_request_id: str | None = None
     linked_run_id: UUID | None = None
     linked_user_message_id: int | None = None
@@ -30,3 +31,5 @@ class SessionQueueItemUpdateRequest(BaseModel):
 
     prompt: str | None = None
     attachments: list[InputFile] | None = None
+    file_references: list[FileReference] | None = None
+    input_file_references: list[FileReference] | None = None

--- a/backend/app/services/executor_manager_client.py
+++ b/backend/app/services/executor_manager_client.py
@@ -7,6 +7,7 @@ class ExecutorManagerClient:
     def __init__(self) -> None:
         settings = get_settings()
         self._base_url = (settings.executor_manager_url or "").rstrip("/")
+        self._internal_headers = {"X-Internal-Token": settings.internal_api_token}
         self._client = httpx.Client(
             base_url=self._base_url,
             timeout=httpx.Timeout(connect=3.0, read=10.0, write=10.0, pool=3.0),
@@ -17,4 +18,5 @@ class ExecutorManagerClient:
         self._client.post(
             "/api/v1/executor/delete",
             json={"container_id": container_id, "reason": "Agent assignment release"},
+            headers=self._internal_headers,
         ).raise_for_status()

--- a/backend/app/services/file_reference_service.py
+++ b/backend/app/services/file_reference_service.py
@@ -180,14 +180,18 @@ class FileReferenceService:
                 continue
 
             inserted_text = reference.inserted_text.strip()
-            if prompt is not None and inserted_text and inserted_text not in prompt_text:
+            if (
+                prompt is not None
+                and inserted_text
+                and inserted_text not in prompt_text
+            ):
                 continue
 
             if isinstance(reference, InputFileReference):
                 source = reference.source.strip()
-                input_file = available_by_source.get(source) or historical_by_source.get(
+                input_file = available_by_source.get(
                     source
-                )
+                ) or historical_by_source.get(source)
                 if input_file is None:
                     raise AppException(
                         error_code=ErrorCode.BAD_REQUEST,

--- a/backend/app/services/file_reference_service.py
+++ b/backend/app/services/file_reference_service.py
@@ -1,4 +1,3 @@
-from pathlib import PurePosixPath
 from typing import Any
 from uuid import UUID
 
@@ -115,36 +114,11 @@ class FileReferenceService:
                 by_source.setdefault(source, input_file)
         return by_source
 
-    @staticmethod
-    def _manifest_object_key(
-        file_entry: dict[str, Any],
-        *,
-        workspace_files_prefix: str | None,
-        path: str,
-    ) -> str | None:
-        raw = (
-            file_entry.get("key")
-            or file_entry.get("object_key")
-            or file_entry.get("oss_key")
-            or file_entry.get("s3_key")
-        )
-        if isinstance(raw, str) and raw.strip():
-            return raw.strip()
-        prefix = (workspace_files_prefix or "").strip().rstrip("/")
-        if prefix:
-            return f"{prefix}/{path.lstrip('/')}"
-        return None
-
-    @staticmethod
-    def _manifest_size(file_entry: dict[str, Any]) -> int | None:
-        raw = file_entry.get("size")
-        return raw if isinstance(raw, int) else None
-
-    def _workspace_reference_to_input_file(
+    def _validate_workspace_reference(
         self,
         db_session: AgentSession,
         reference: WorkspaceFileReference,
-    ) -> InputFile:
+    ) -> WorkspaceFileReference:
         if reference.session_id != str(db_session.id):
             raise AppException(
                 error_code=ErrorCode.BAD_REQUEST,
@@ -173,28 +147,7 @@ class FileReferenceService:
                 message="workspace_file reference path does not exist",
             )
 
-        object_key = self._manifest_object_key(
-            file_entry,
-            workspace_files_prefix=db_session.workspace_files_prefix,
-            path=normalized_path,
-        )
-        if not object_key:
-            raise AppException(
-                error_code=ErrorCode.BAD_REQUEST,
-                message="workspace_file reference is missing object storage key",
-            )
-
-        name = PurePosixPath(normalized_path).name or reference.display_name
-        content_type = file_entry.get("mimeType") or file_entry.get("mime_type")
-        return InputFile(
-            id=f"workspace:{db_session.id}:{normalized_path}",
-            type="file",
-            name=name,
-            source=object_key,
-            size=self._manifest_size(file_entry),
-            content_type=content_type if isinstance(content_type, str) else None,
-            path=normalized_path.lstrip("/"),
-        )
+        return reference.model_copy(update={"path": normalized_path})
 
     def resolve_for_run(
         self,
@@ -242,7 +195,7 @@ class FileReferenceService:
                     )
                 add_input(input_file)
             else:
-                add_input(self._workspace_reference_to_input_file(db_session, reference))
+                reference = self._validate_workspace_reference(db_session, reference)
 
             normalized_references.append(self._reference_to_dict(reference))
 

--- a/backend/app/services/file_reference_service.py
+++ b/backend/app/services/file_reference_service.py
@@ -1,0 +1,249 @@
+from pathlib import PurePosixPath
+from typing import Any
+from uuid import UUID
+
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from app.core.errors.error_codes import ErrorCode
+from app.core.errors.exceptions import AppException
+from app.models.agent_run import AgentRun
+from app.models.agent_session import AgentSession
+from app.schemas.input_file import (
+    FileReference,
+    InputFile,
+    InputFileReference,
+    WorkspaceFileReference,
+)
+from app.services.storage_service import S3StorageService
+from app.utils.workspace_manifest import find_manifest_file, normalize_manifest_path
+
+
+class FileReferenceService:
+    def __init__(self, storage_service: S3StorageService | None = None) -> None:
+        self._storage_service = storage_service
+
+    @property
+    def storage_service(self) -> S3StorageService:
+        if self._storage_service is None:
+            self._storage_service = S3StorageService()
+        return self._storage_service
+
+    @staticmethod
+    def get_config_references(config: Any) -> list[FileReference]:
+        if config is None:
+            return []
+        references = getattr(config, "file_references", None) or getattr(
+            config, "input_file_references", None
+        )
+        return list(references or [])
+
+    @staticmethod
+    def _input_file_from_raw(value: InputFile | dict[str, Any]) -> InputFile | None:
+        if isinstance(value, InputFile):
+            return value
+        if not isinstance(value, dict):
+            return None
+        try:
+            return InputFile.model_validate(value)
+        except ValidationError:
+            return None
+
+    @staticmethod
+    def _input_file_source(input_file: InputFile) -> str:
+        return (input_file.source or "").strip()
+
+    @staticmethod
+    def _reference_from_raw(
+        reference: FileReference | dict[str, Any],
+    ) -> FileReference | None:
+        if isinstance(reference, (InputFileReference, WorkspaceFileReference)):
+            return reference
+        if not isinstance(reference, dict):
+            return None
+
+        kind = str(reference.get("kind") or "").strip()
+        try:
+            if kind == "input_file":
+                return InputFileReference.model_validate(reference)
+            if kind == "workspace_file":
+                return WorkspaceFileReference.model_validate(reference)
+        except ValidationError:
+            return None
+        return None
+
+    @staticmethod
+    def _reference_to_dict(reference: FileReference) -> dict[str, Any]:
+        return reference.model_dump(mode="json", by_alias=True)
+
+    @classmethod
+    def _collect_input_by_source(
+        cls,
+        input_files: list[InputFile] | list[dict[str, Any]],
+    ) -> dict[str, InputFile]:
+        by_source: dict[str, InputFile] = {}
+        for raw_input_file in input_files:
+            input_file = cls._input_file_from_raw(raw_input_file)
+            if input_file is None:
+                continue
+            source = cls._input_file_source(input_file)
+            if source and source not in by_source:
+                by_source[source] = input_file
+        return by_source
+
+    @classmethod
+    def _collect_historical_inputs(
+        cls,
+        db: Session,
+        session_id: UUID,
+    ) -> dict[str, InputFile]:
+        by_source: dict[str, InputFile] = {}
+        runs = (
+            db.query(AgentRun)
+            .filter(AgentRun.session_id == session_id)
+            .order_by(AgentRun.created_at.asc())
+            .all()
+        )
+        for run in runs:
+            snapshot = run.config_snapshot or {}
+            if not isinstance(snapshot, dict):
+                continue
+            raw_inputs = snapshot.get("input_files")
+            if not isinstance(raw_inputs, list):
+                continue
+            for source, input_file in cls._collect_input_by_source(raw_inputs).items():
+                by_source.setdefault(source, input_file)
+        return by_source
+
+    @staticmethod
+    def _manifest_object_key(
+        file_entry: dict[str, Any],
+        *,
+        workspace_files_prefix: str | None,
+        path: str,
+    ) -> str | None:
+        raw = (
+            file_entry.get("key")
+            or file_entry.get("object_key")
+            or file_entry.get("oss_key")
+            or file_entry.get("s3_key")
+        )
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+        prefix = (workspace_files_prefix or "").strip().rstrip("/")
+        if prefix:
+            return f"{prefix}/{path.lstrip('/')}"
+        return None
+
+    @staticmethod
+    def _manifest_size(file_entry: dict[str, Any]) -> int | None:
+        raw = file_entry.get("size")
+        return raw if isinstance(raw, int) else None
+
+    def _workspace_reference_to_input_file(
+        self,
+        db_session: AgentSession,
+        reference: WorkspaceFileReference,
+    ) -> InputFile:
+        if reference.session_id != str(db_session.id):
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="workspace_file reference must target the current session",
+            )
+
+        manifest_key = (db_session.workspace_manifest_key or "").strip()
+        if db_session.workspace_export_status != "ready" or not manifest_key:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="Session workspace export is not ready",
+            )
+
+        normalized_path = normalize_manifest_path(reference.path)
+        if not normalized_path:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="Invalid workspace_file reference path",
+            )
+
+        manifest = self.storage_service.get_manifest(manifest_key)
+        file_entry = find_manifest_file(manifest, normalized_path)
+        if file_entry is None:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="workspace_file reference path does not exist",
+            )
+
+        object_key = self._manifest_object_key(
+            file_entry,
+            workspace_files_prefix=db_session.workspace_files_prefix,
+            path=normalized_path,
+        )
+        if not object_key:
+            raise AppException(
+                error_code=ErrorCode.BAD_REQUEST,
+                message="workspace_file reference is missing object storage key",
+            )
+
+        name = PurePosixPath(normalized_path).name or reference.display_name
+        content_type = file_entry.get("mimeType") or file_entry.get("mime_type")
+        return InputFile(
+            id=f"workspace:{db_session.id}:{normalized_path}",
+            type="file",
+            name=name,
+            source=object_key,
+            size=self._manifest_size(file_entry),
+            content_type=content_type if isinstance(content_type, str) else None,
+            path=normalized_path.lstrip("/"),
+        )
+
+    def resolve_for_run(
+        self,
+        db: Session,
+        db_session: AgentSession,
+        references: list[FileReference] | list[dict[str, Any]] | None,
+        input_files: list[InputFile],
+        *,
+        prompt: str | None = None,
+    ) -> tuple[list[InputFile], list[dict[str, Any]]]:
+        if not references:
+            return input_files, []
+
+        merged_inputs = list(input_files)
+        available_by_source = self._collect_input_by_source(merged_inputs)
+        historical_by_source = self._collect_historical_inputs(db, db_session.id)
+        normalized_references: list[dict[str, Any]] = []
+        prompt_text = prompt or ""
+
+        def add_input(input_file: InputFile) -> None:
+            source = self._input_file_source(input_file)
+            if not source or source in available_by_source:
+                return
+            available_by_source[source] = input_file
+            merged_inputs.append(input_file)
+
+        for raw_reference in references:
+            reference = self._reference_from_raw(raw_reference)
+            if reference is None:
+                continue
+
+            inserted_text = reference.inserted_text.strip()
+            if prompt is not None and inserted_text and inserted_text not in prompt_text:
+                continue
+
+            if isinstance(reference, InputFileReference):
+                source = reference.source.strip()
+                input_file = available_by_source.get(source) or historical_by_source.get(
+                    source
+                )
+                if input_file is None:
+                    raise AppException(
+                        error_code=ErrorCode.BAD_REQUEST,
+                        message="input_file reference source does not exist in this session",
+                    )
+                add_input(input_file)
+            else:
+                add_input(self._workspace_reference_to_input_file(db_session, reference))
+
+            normalized_references.append(self._reference_to_dict(reference))
+
+        return merged_inputs, normalized_references

--- a/backend/app/services/session_queue_service.py
+++ b/backend/app/services/session_queue_service.py
@@ -13,6 +13,7 @@ from app.models.session_queue_item import AgentSessionQueueItem
 from app.repositories.message_repository import MessageRepository
 from app.repositories.run_repository import RunRepository
 from app.repositories.session_queue_item_repository import SessionQueueItemRepository
+from app.services.file_reference_service import FileReferenceService
 from app.schemas.session_queue_item import (
     SessionQueueItemResponse,
     SessionQueueItemUpdateRequest,
@@ -39,6 +40,8 @@ class SessionQueueService:
             return None
         session_config = dict(run_config_snapshot)
         session_config.pop("input_files", None)
+        session_config.pop("file_references", None)
+        session_config.pop("input_file_references", None)
         return session_config or None
 
     @staticmethod
@@ -67,10 +70,16 @@ class SessionQueueService:
     ) -> dict[str, Any] | None:
         if not isinstance(run_config_snapshot, dict):
             return None
+        metadata: dict[str, Any] = {}
         trigger_context = run_config_snapshot.get("trigger_context")
-        if not isinstance(trigger_context, dict):
-            return None
-        return {"trigger_context": trigger_context}
+        if isinstance(trigger_context, dict):
+            metadata["trigger_context"] = trigger_context
+        file_references = run_config_snapshot.get("file_references")
+        if file_references is None:
+            file_references = run_config_snapshot.get("input_file_references")
+        if isinstance(file_references, list) and file_references:
+            metadata["file_references"] = file_references
+        return metadata or None
 
     @staticmethod
     def _move_item_to_front(
@@ -301,7 +310,12 @@ class SessionQueueService:
         if request.prompt is not None:
             item.prompt = self._normalize_prompt(request.prompt)
 
-        if request.attachments is not None:
+        if (
+            request.prompt is not None
+            or request.attachments is not None
+            or request.file_references is not None
+            or request.input_file_references is not None
+        ):
             snapshot = (
                 dict(item.run_config_snapshot)
                 if isinstance(item.run_config_snapshot, dict)
@@ -312,8 +326,46 @@ class SessionQueueService:
                     attachment.model_dump(mode="json")
                     for attachment in request.attachments
                 ]
+            elif request.attachments is not None:
+                snapshot.pop("input_files", None)
+            input_files = snapshot.get("input_files")
+            if not isinstance(input_files, list):
+                input_files = []
+            requested_references = (
+                request.file_references
+                if request.file_references is not None
+                else request.input_file_references
+            )
+            if requested_references is None:
+                requested_references = snapshot.get("file_references")
+                if requested_references is None:
+                    requested_references = snapshot.get("input_file_references")
+            current_input_files = []
+            for raw_input in input_files:
+                input_file = FileReferenceService._input_file_from_raw(raw_input)
+                if input_file is not None:
+                    current_input_files.append(input_file)
+            merged_input_files, normalized_file_references = (
+                FileReferenceService().resolve_for_run(
+                    db,
+                    db_session,
+                    requested_references,
+                    current_input_files,
+                    prompt=item.prompt,
+                )
+            )
+            if merged_input_files:
+                snapshot["input_files"] = [
+                    input_file.model_dump(mode="json")
+                    for input_file in merged_input_files
+                ]
             else:
                 snapshot.pop("input_files", None)
+            if normalized_file_references:
+                snapshot["file_references"] = normalized_file_references
+            else:
+                snapshot.pop("file_references", None)
+            snapshot.pop("input_file_references", None)
             item.run_config_snapshot = snapshot or None
 
         db.flush()

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -59,6 +59,24 @@ class SessionService:
             return deepcopy(value)
         return value
 
+    @staticmethod
+    def _filter_file_references_for_prompt(
+        references: Any,
+        prompt: str | None = None,
+    ) -> list[dict[str, Any]]:
+        if not isinstance(references, list):
+            return []
+        prompt_text = prompt or ""
+        filtered: list[dict[str, Any]] = []
+        for reference in references:
+            if not isinstance(reference, dict):
+                continue
+            inserted_text = str(reference.get("insertedText") or "").strip()
+            if prompt is not None and inserted_text and inserted_text not in prompt_text:
+                continue
+            filtered.append(SessionService._deepcopy_json(reference))
+        return filtered
+
     def _ensure_no_active_queue_items(self, db: Session, session_id: uuid.UUID) -> None:
         if SessionQueueItemRepository.has_active_items(db, session_id):
             raise AppException(
@@ -1152,6 +1170,16 @@ class SessionService:
             input_files = latest_target_run.config_snapshot.get("input_files")
             if isinstance(input_files, list):
                 run_config_snapshot["input_files"] = self._deepcopy_json(input_files)
+            file_references = latest_target_run.config_snapshot.get("file_references")
+            if file_references is None:
+                file_references = latest_target_run.config_snapshot.get(
+                    "input_file_references"
+                )
+            normalized_file_references = self._filter_file_references_for_prompt(
+                file_references
+            )
+            if normalized_file_references:
+                run_config_snapshot["file_references"] = normalized_file_references
         # Override model with current selection if provided
         if model is not None:
             run_config_snapshot["model"] = model
@@ -1270,6 +1298,19 @@ class SessionService:
             input_files = latest_target_run.config_snapshot.get("input_files")
             if isinstance(input_files, list):
                 run_config_snapshot["input_files"] = self._deepcopy_json(input_files)
+            file_references = latest_target_run.config_snapshot.get("file_references")
+            if file_references is None:
+                file_references = latest_target_run.config_snapshot.get(
+                    "input_file_references"
+                )
+            normalized_file_references = self._filter_file_references_for_prompt(
+                file_references,
+                prompt,
+            )
+            if normalized_file_references:
+                run_config_snapshot["file_references"] = normalized_file_references
+            else:
+                run_config_snapshot.pop("file_references", None)
         # Override model with current selection if provided
         if model is not None:
             run_config_snapshot["model"] = model
@@ -1280,6 +1321,11 @@ class SessionService:
             "_type": "UserMessage",
             "content": [{"_type": "TextBlock", "text": prompt}],
         }
+        metadata = SessionQueueService._message_metadata_from_run_snapshot(
+            run_config_snapshot
+        )
+        if metadata is not None:
+            user_message.content["metadata"] = metadata
         user_message.text_preview = prompt[:500]
 
         runs_to_delete = (

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -72,7 +72,11 @@ class SessionService:
             if not isinstance(reference, dict):
                 continue
             inserted_text = str(reference.get("insertedText") or "").strip()
-            if prompt is not None and inserted_text and inserted_text not in prompt_text:
+            if (
+                prompt is not None
+                and inserted_text
+                and inserted_text not in prompt_text
+            ):
                 continue
             filtered.append(SessionService._deepcopy_json(reference))
         return filtered

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -29,6 +29,7 @@ from app.services.capability_policy import (
     resolve_effective_enabled,
 )
 from app.services.env_var_service import EnvVarService
+from app.services.file_reference_service import FileReferenceService
 from app.services.model_config_service import (
     PROVIDER_SPEC_MAP,
     get_allowed_model_ids,
@@ -448,14 +449,27 @@ class TaskService:
         )
 
         run_config_snapshot = dict(merged_config or {})
+        file_reference_service = FileReferenceService()
         merged_input_files = self._merge_input_files(
             self._build_project_input_files(db, project),
             request.config.input_files if request.config is not None else None,
+        )
+        file_references = FileReferenceService.get_config_references(request.config)
+        merged_input_files, normalized_file_references = (
+            file_reference_service.resolve_for_run(
+                db,
+                db_session,
+                file_references,
+                merged_input_files,
+                prompt=prompt,
+            )
         )
         if merged_input_files:
             run_config_snapshot["input_files"] = [
                 f.model_dump(mode="json") for f in merged_input_files
             ]
+        if normalized_file_references:
+            run_config_snapshot["file_references"] = normalized_file_references
         run_config_snapshot = run_config_snapshot or None
 
         if (
@@ -584,6 +598,8 @@ class TaskService:
         merged_base.pop("plugin_files", None)
         # input_files are treated as per-run inputs and should not be persisted into the session-level config snapshot.
         merged_base.pop("input_files", None)
+        merged_base.pop("file_references", None)
+        merged_base.pop("input_file_references", None)
 
         base_mcp_server_ids = self._normalize_mcp_server_ids(
             merged_base.get("mcp_server_ids")
@@ -603,6 +619,8 @@ class TaskService:
             )
             # input_files are per-run and should not be merged into session config.
             request_config.pop("input_files", None)
+            request_config.pop("file_references", None)
+            request_config.pop("input_file_references", None)
             # Extract mcp_config toggles before merging (don't merge as dict)
             request_mcp_toggles = normalize_override_map(
                 request_config.pop("mcp_config", None)

--- a/backend/tests/test_executor_manager_client.py
+++ b/backend/tests/test_executor_manager_client.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.services.executor_manager_client import ExecutorManagerClient
+
+
+class ExecutorManagerClientTests(unittest.TestCase):
+    def test_delete_container_sends_internal_token(self) -> None:
+        settings = MagicMock(
+            executor_manager_url="http://executor-manager",
+            internal_api_token="internal-token",
+        )
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        http_client = MagicMock()
+        http_client.post.return_value = response
+
+        with (
+            patch(
+                "app.services.executor_manager_client.get_settings",
+                return_value=settings,
+            ),
+            patch(
+                "app.services.executor_manager_client.httpx.Client",
+                return_value=http_client,
+            ),
+        ):
+            ExecutorManagerClient().delete_container("container-1")
+
+        http_client.post.assert_called_once()
+        _, kwargs = http_client.post.call_args
+        self.assertEqual(kwargs["headers"]["X-Internal-Token"], "internal-token")
+        self.assertEqual(kwargs["json"]["container_id"], "container-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_file_reference_service.py
+++ b/backend/tests/test_file_reference_service.py
@@ -27,7 +27,7 @@ class FileReferenceServiceTests(unittest.TestCase):
             workspace_files_prefix="workspaces/user/session/files",
         )
 
-    def test_resolves_workspace_reference_to_synthetic_input(self) -> None:
+    def test_validates_workspace_reference_without_promoting_to_input(self) -> None:
         service = FileReferenceService(
             storage_service=FakeStorageService(
                 {
@@ -63,13 +63,9 @@ class FileReferenceServiceTests(unittest.TestCase):
                 prompt="read #summary.md",
             )
 
-        self.assertEqual(len(input_files), 1)
-        self.assertEqual(
-            input_files[0].source,
-            "workspaces/user/session/files/reports/summary.md",
-        )
-        self.assertEqual(input_files[0].path, "reports/summary.md")
+        self.assertEqual(input_files, [])
         self.assertEqual(references[0]["kind"], "workspace_file")
+        self.assertEqual(references[0]["path"], "/reports/summary.md")
 
     def test_rejects_missing_workspace_reference_path(self) -> None:
         service = FileReferenceService(storage_service=FakeStorageService({"files": []}))

--- a/backend/tests/test_file_reference_service.py
+++ b/backend/tests/test_file_reference_service.py
@@ -1,0 +1,134 @@
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.core.errors.exceptions import AppException
+from app.schemas.input_file import InputFile
+from app.services.file_reference_service import FileReferenceService
+
+
+class FakeStorageService:
+    def __init__(self, manifest: dict) -> None:
+        self.manifest = manifest
+
+    def get_manifest(self, key: str) -> dict:
+        return self.manifest
+
+
+class FileReferenceServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session_id = uuid.uuid4()
+        self.db = MagicMock()
+        self.db_session = SimpleNamespace(
+            id=self.session_id,
+            workspace_export_status="ready",
+            workspace_manifest_key="workspaces/user/session/manifest.json",
+            workspace_files_prefix="workspaces/user/session/files",
+        )
+
+    def test_resolves_workspace_reference_to_synthetic_input(self) -> None:
+        service = FileReferenceService(
+            storage_service=FakeStorageService(
+                {
+                    "files": [
+                        {
+                            "path": "reports/summary.md",
+                            "key": "workspaces/user/session/files/reports/summary.md",
+                            "size": 42,
+                            "mimeType": "text/markdown",
+                        }
+                    ]
+                }
+            )
+        )
+
+        with patch.object(
+            FileReferenceService, "_collect_historical_inputs", return_value={}
+        ):
+            input_files, references = service.resolve_for_run(
+                self.db,
+                self.db_session,
+                [
+                    {
+                        "id": "ref-1",
+                        "kind": "workspace_file",
+                        "sessionId": str(self.session_id),
+                        "path": "/reports/summary.md",
+                        "insertedText": "#summary.md",
+                        "displayName": "summary.md",
+                    }
+                ],
+                [],
+                prompt="read #summary.md",
+            )
+
+        self.assertEqual(len(input_files), 1)
+        self.assertEqual(
+            input_files[0].source,
+            "workspaces/user/session/files/reports/summary.md",
+        )
+        self.assertEqual(input_files[0].path, "reports/summary.md")
+        self.assertEqual(references[0]["kind"], "workspace_file")
+
+    def test_rejects_missing_workspace_reference_path(self) -> None:
+        service = FileReferenceService(storage_service=FakeStorageService({"files": []}))
+
+        with (
+            patch.object(
+                FileReferenceService, "_collect_historical_inputs", return_value={}
+            ),
+            self.assertRaises(AppException),
+        ):
+            service.resolve_for_run(
+                self.db,
+                self.db_session,
+                [
+                    {
+                        "id": "ref-1",
+                        "kind": "workspace_file",
+                        "sessionId": str(self.session_id),
+                        "path": "/missing.md",
+                        "insertedText": "#missing.md",
+                        "displayName": "missing.md",
+                    }
+                ],
+                [],
+            )
+
+    def test_promotes_historical_input_file_reference(self) -> None:
+        historical_input = InputFile(
+            name="guide.md",
+            source="attachments/user/file",
+            size=12,
+            content_type="text/markdown",
+        )
+        service = FileReferenceService()
+
+        with patch.object(
+            FileReferenceService,
+            "_collect_historical_inputs",
+            return_value={"attachments/user/file": historical_input},
+        ):
+            input_files, references = service.resolve_for_run(
+                self.db,
+                self.db_session,
+                [
+                    {
+                        "id": "ref-1",
+                        "kind": "input_file",
+                        "source": "attachments/user/file",
+                        "insertedText": "#guide.md",
+                        "displayName": "guide.md",
+                    }
+                ],
+                [],
+                prompt="check #guide.md",
+            )
+
+        self.assertEqual(input_files, [historical_input])
+        self.assertEqual(references[0]["kind"], "input_file")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_file_reference_service.py
+++ b/backend/tests/test_file_reference_service.py
@@ -1,18 +1,20 @@
 import unittest
 import uuid
-from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from app.core.errors.exceptions import AppException
+from app.models.agent_session import AgentSession
 from app.schemas.input_file import InputFile
 from app.services.file_reference_service import FileReferenceService
+from app.services.storage_service import S3StorageService
 
 
-class FakeStorageService:
-    def __init__(self, manifest: dict) -> None:
+class FakeStorageService(S3StorageService):
+    def __init__(self, manifest: dict[str, Any]) -> None:
         self.manifest = manifest
 
-    def get_manifest(self, key: str) -> dict:
+    def get_manifest(self, key: str) -> dict[str, Any]:
         return self.manifest
 
 
@@ -20,8 +22,11 @@ class FileReferenceServiceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.session_id = uuid.uuid4()
         self.db = MagicMock()
-        self.db_session = SimpleNamespace(
+        self.db_session = AgentSession(
             id=self.session_id,
+            user_id="user-1",
+            kind="chat",
+            status="running",
             workspace_export_status="ready",
             workspace_manifest_key="workspaces/user/session/manifest.json",
             workspace_files_prefix="workspaces/user/session/files",
@@ -68,7 +73,9 @@ class FileReferenceServiceTests(unittest.TestCase):
         self.assertEqual(references[0]["path"], "/reports/summary.md")
 
     def test_rejects_missing_workspace_reference_path(self) -> None:
-        service = FileReferenceService(storage_service=FakeStorageService({"files": []}))
+        service = FileReferenceService(
+            storage_service=FakeStorageService({"files": []})
+        )
 
         with (
             patch.object(

--- a/backend/tests/test_schedules_proxy.py
+++ b/backend/tests/test_schedules_proxy.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1.schedules import router
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    def read(self) -> bytes:
+        return b'{"code":0,"data":{"rules":[]},"message":"ok"}'
+
+
+class SchedulesProxyTests(unittest.TestCase):
+    def test_schedules_proxy_sends_internal_token_to_executor_manager(self) -> None:
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+        settings = MagicMock(
+            executor_manager_url="http://executor-manager",
+            internal_api_token="internal-token",
+        )
+
+        with (
+            patch("app.api.v1.schedules.get_settings", return_value=settings),
+            patch("app.api.v1.schedules.urlopen", return_value=_Response()) as open_url,
+        ):
+            response = TestClient(app).get("/api/v1/schedules")
+
+        self.assertEqual(response.status_code, 200)
+        request = open_url.call_args.args[0]
+        self.assertEqual(request.get_header("X-internal-token"), "internal-token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_session_queue_service.py
+++ b/backend/tests/test_session_queue_service.py
@@ -70,6 +70,42 @@ class SessionQueueServiceTests(unittest.TestCase):
             "Please review this change",
         )
 
+    def test_materialize_run_persists_file_references_in_message_metadata(self) -> None:
+        file_references = [
+            {
+                "id": "ref-1",
+                "kind": "workspace_file",
+                "sessionId": str(self.db_session.id),
+                "path": "/reports/summary.md",
+                "insertedText": "#summary.md",
+                "displayName": "summary.md",
+            }
+        ]
+        db_message = SimpleNamespace(id=123)
+        db_run = SimpleNamespace(id=uuid.uuid4())
+
+        with (
+            patch(
+                "app.services.session_queue_service.MessageRepository.create",
+                return_value=db_message,
+            ) as create_message,
+            patch(
+                "app.services.session_queue_service.RunRepository.create",
+                return_value=db_run,
+            ),
+        ):
+            self.service.materialize_run(
+                self.db,
+                db_session=self.db_session,
+                prompt="Please read #summary.md",
+                permission_mode="default",
+                schedule_mode="immediate",
+                run_config_snapshot={"file_references": file_references},
+            )
+
+        content = create_message.call_args.kwargs["content"]
+        self.assertEqual(content["metadata"]["file_references"], file_references)
+
     def test_materialize_run_keeps_plain_user_messages_without_metadata(self) -> None:
         db_message = SimpleNamespace(id=123)
         db_run = SimpleNamespace(id=uuid.uuid4())

--- a/executor/app/api/v1/task.py
+++ b/executor/app/api/v1/task.py
@@ -50,19 +50,36 @@ async def run_task(req: TaskRun, background_tasks: BackgroundTasks) -> dict:
     Returns:
         Accepted status with session ID.
     """
-    callback_client = CallbackClient(callback_url=req.callback_url)
+    callback_client = CallbackClient(
+        callback_url=req.callback_url,
+        callback_token=req.callback_token,
+    )
     base_url = UserInputClient.resolve_base_url(
         callback_url=req.callback_url, callback_base_url=req.callback_base_url
     )
-    user_input_client = UserInputClient(base_url=base_url)
-    computer_client = ComputerClient(base_url=base_url)
+    user_input_client = UserInputClient(
+        base_url=base_url,
+        callback_token=req.callback_token,
+    )
+    computer_client = ComputerClient(
+        base_url=base_url,
+        callback_token=req.callback_token,
+    )
     memory_client = (
-        MemoryClient(base_url=base_url, session_id=req.session_id)
+        MemoryClient(
+            base_url=base_url,
+            session_id=req.session_id,
+            callback_token=req.callback_token,
+        )
         if req.config.memory_enabled
         else None
     )
     channel_runtime_client = (
-        ChannelRuntimeClient(base_url=base_url, session_id=req.session_id)
+        ChannelRuntimeClient(
+            base_url=base_url,
+            session_id=req.session_id,
+            callback_token=req.callback_token,
+        )
         if req.config.server_id
         and req.config.channel_id
         and req.config.agent_identity_id

--- a/executor/app/core/callback.py
+++ b/executor/app/core/callback.py
@@ -10,9 +10,24 @@ from app.core.observability.request_context import (
 
 
 class CallbackClient:
-    def __init__(self, callback_url: str, timeout: float = 30.0):
+    def __init__(
+        self,
+        callback_url: str,
+        callback_token: str = "",
+        timeout: float = 30.0,
+    ):
         self.callback_url = callback_url
+        self.callback_token = callback_token
         self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def send(self, report: AgentCallbackRequest) -> bool:
         try:
@@ -20,10 +35,7 @@ class CallbackClient:
                 response = await client.post(
                     self.callback_url,
                     json=report.model_dump(mode="json"),
-                    headers={
-                        "X-Request-ID": get_request_id() or generate_request_id(),
-                        "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                    },
+                    headers=self._headers(),
                 )
                 return response.is_success
         except httpx.RequestError:

--- a/executor/app/core/channel_runtime.py
+++ b/executor/app/core/channel_runtime.py
@@ -75,24 +75,33 @@ def stage_downloaded_artifact(
 
 
 class ChannelRuntimeClient:
-    def __init__(self, base_url: str, session_id: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        session_id: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session_id = session_id
+        self.callback_token = callback_token
         self.timeout = timeout
 
-    @staticmethod
-    def _trace_headers() -> dict[str, str]:
-        return {
+    def _headers(self) -> dict[str, str]:
+        headers = {
             "X-Request-ID": get_request_id() or generate_request_id(),
             "X-Trace-ID": get_trace_id() or generate_trace_id(),
         }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def _request(self, path: str, payload: dict[str, Any]) -> Any:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.base_url}{path}",
                 json={"session_id": self.session_id, **payload},
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
 
         body = response.json()
@@ -222,7 +231,7 @@ class ChannelRuntimeClient:
                     "artifact_id": artifact_id,
                     "logical_path": logical_path,
                 },
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
 
         if response.is_error:

--- a/executor/app/core/computer.py
+++ b/executor/app/core/computer.py
@@ -15,9 +15,24 @@ logger = logging.getLogger(__name__)
 class ComputerClient:
     """Client for sending Poco Computer artifacts to Executor Manager."""
 
-    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.callback_token = callback_token
         self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def upload_browser_screenshot(
         self,
@@ -39,10 +54,7 @@ class ComputerClient:
                     files={
                         "file": ("screenshot.png", png_bytes, "image/png"),
                     },
-                    headers={
-                        "X-Request-ID": get_request_id() or generate_request_id(),
-                        "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                    },
+                    headers=self._headers(),
                 )
                 if not response.is_success:
                     logger.warning(

--- a/executor/app/core/engine.py
+++ b/executor/app/core/engine.py
@@ -7,7 +7,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from claude_agent_sdk import ClaudeAgentOptions
 from claude_agent_sdk.types import (
@@ -499,21 +499,94 @@ class AgentExecutor:
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
+    @staticmethod
+    def _input_hint_display_path(input_file: object) -> str | None:
+        path = getattr(input_file, "path", None) or ""
+        name = getattr(input_file, "name", None) or ""
+        if path:
+            return str(path).lstrip("/")
+        if name:
+            return f"inputs/{name}"
+        return None
+
+    @staticmethod
+    def _input_hint_relative_path(input_file: object) -> str | None:
+        display = AgentExecutor._input_hint_display_path(input_file)
+        if not display:
+            return None
+        return display.removeprefix("inputs/").lstrip("/")
+
+    @staticmethod
+    def _normalized_workspace_reference_path(reference: dict[str, Any]) -> str:
+        raw_path = str(reference.get("path") or "").replace("\\", "/").strip()
+        return raw_path.lstrip("/")
+
+    @classmethod
+    def _build_file_reference_hint_lines(
+        cls,
+        references: list[dict[str, Any]],
+        inputs: list[object],
+    ) -> list[str]:
+        if not references or not inputs:
+            return []
+
+        inputs_by_source: dict[str, object] = {}
+        inputs_by_relative_path: dict[str, object] = {}
+        for input_file in inputs:
+            source = str(getattr(input_file, "source", "") or "").strip()
+            if source:
+                inputs_by_source.setdefault(source, input_file)
+            relative_path = cls._input_hint_relative_path(input_file)
+            if relative_path:
+                inputs_by_relative_path.setdefault(relative_path, input_file)
+
+        lines: list[str] = []
+        for reference in references:
+            if not isinstance(reference, dict):
+                continue
+
+            kind = str(reference.get("kind") or "").strip()
+            input_file = None
+            if kind == "input_file":
+                source = str(reference.get("source") or "").strip()
+                input_file = inputs_by_source.get(source)
+            elif kind == "workspace_file":
+                path = cls._normalized_workspace_reference_path(reference)
+                input_file = inputs_by_relative_path.get(path)
+
+            display_path = (
+                cls._input_hint_display_path(input_file) if input_file else None
+            )
+            inserted_text = str(
+                reference.get("insertedText")
+                or reference.get("inserted_text")
+                or reference.get("displayName")
+                or reference.get("display_name")
+                or ""
+            ).strip()
+            if display_path and inserted_text:
+                lines.append(f"- {inserted_text} -> {display_path}")
+
+        return lines
+
     def _build_input_hint(self, config: TaskConfig) -> str | None:
         lines: list[str] = []
         inputs = config.input_files or []
         if inputs:
             lines.append(
-                "User-uploaded inputs are available under inputs/ (or /workspace/inputs):"
+                "Input files for this run are available under inputs/ (or /workspace/inputs):"
             )
             for item in inputs:
-                path = getattr(item, "path", None) or ""
-                name = getattr(item, "name", None) or ""
-                display = (
-                    path.lstrip("/") if path else (f"inputs/{name}" if name else "")
-                )
+                display = self._input_hint_display_path(item)
                 if display:
                     lines.append(f"- {display}")
+            reference_lines = self._build_file_reference_hint_lines(
+                config.file_references or config.input_file_references or [],
+                list(inputs),
+            )
+            if reference_lines:
+                lines.append("Referenced files in the user prompt resolve to:")
+                lines.extend(reference_lines)
             lines.append("Do not modify files under inputs/ unless the user asks.")
 
         mounts = config.resolved_local_mounts or []

--- a/executor/app/core/engine.py
+++ b/executor/app/core/engine.py
@@ -510,16 +510,19 @@ class AgentExecutor:
         return None
 
     @staticmethod
-    def _input_hint_relative_path(input_file: object) -> str | None:
-        display = AgentExecutor._input_hint_display_path(input_file)
-        if not display:
-            return None
-        return display.removeprefix("inputs/").lstrip("/")
-
-    @staticmethod
     def _normalized_workspace_reference_path(reference: dict[str, Any]) -> str:
         raw_path = str(reference.get("path") or "").replace("\\", "/").strip()
         return raw_path.lstrip("/")
+
+    @staticmethod
+    def _reference_inserted_text(reference: dict[str, Any]) -> str:
+        return str(
+            reference.get("insertedText")
+            or reference.get("inserted_text")
+            or reference.get("displayName")
+            or reference.get("display_name")
+            or ""
+        ).strip()
 
     @classmethod
     def _build_file_reference_hint_lines(
@@ -527,18 +530,14 @@ class AgentExecutor:
         references: list[dict[str, Any]],
         inputs: list[object],
     ) -> list[str]:
-        if not references or not inputs:
+        if not references:
             return []
 
         inputs_by_source: dict[str, object] = {}
-        inputs_by_relative_path: dict[str, object] = {}
         for input_file in inputs:
             source = str(getattr(input_file, "source", "") or "").strip()
             if source:
                 inputs_by_source.setdefault(source, input_file)
-            relative_path = cls._input_hint_relative_path(input_file)
-            if relative_path:
-                inputs_by_relative_path.setdefault(relative_path, input_file)
 
         lines: list[str] = []
         for reference in references:
@@ -546,33 +545,42 @@ class AgentExecutor:
                 continue
 
             kind = str(reference.get("kind") or "").strip()
-            input_file = None
+            inserted_text = cls._reference_inserted_text(reference)
+            if not inserted_text:
+                continue
+
             if kind == "input_file":
                 source = str(reference.get("source") or "").strip()
                 input_file = inputs_by_source.get(source)
+                display_path = (
+                    cls._input_hint_display_path(input_file) if input_file else None
+                )
+                if display_path:
+                    lines.append(f"- {inserted_text} -> {display_path}")
             elif kind == "workspace_file":
                 path = cls._normalized_workspace_reference_path(reference)
-                input_file = inputs_by_relative_path.get(path)
-
-            display_path = (
-                cls._input_hint_display_path(input_file) if input_file else None
-            )
-            inserted_text = str(
-                reference.get("insertedText")
-                or reference.get("inserted_text")
-                or reference.get("displayName")
-                or reference.get("display_name")
-                or ""
-            ).strip()
-            if display_path and inserted_text:
-                lines.append(f"- {inserted_text} -> {display_path}")
+                if path:
+                    lines.append(f"- {inserted_text} -> /workspace/{path}")
 
         return lines
 
     def _build_input_hint(self, config: TaskConfig) -> str | None:
         lines: list[str] = []
         inputs = config.input_files or []
+        file_reference_lines = self._build_file_reference_hint_lines(
+            config.file_references or config.input_file_references or [],
+            list(inputs),
+        )
+        if file_reference_lines:
+            lines.append("Referenced files in the user prompt resolve to:")
+            lines.extend(file_reference_lines)
+            lines.append(
+                "Use /workspace paths for workspace file references. Do not guess a matching /inputs path unless the mapping above explicitly starts with inputs/."
+            )
+
         if inputs:
+            if lines:
+                lines.append("")
             lines.append(
                 "Input files for this run are available under inputs/ (or /workspace/inputs):"
             )
@@ -580,13 +588,6 @@ class AgentExecutor:
                 display = self._input_hint_display_path(item)
                 if display:
                     lines.append(f"- {display}")
-            reference_lines = self._build_file_reference_hint_lines(
-                config.file_references or config.input_file_references or [],
-                list(inputs),
-            )
-            if reference_lines:
-                lines.append("Referenced files in the user prompt resolve to:")
-                lines.extend(reference_lines)
             lines.append("Do not modify files under inputs/ unless the user asks.")
 
         mounts = config.resolved_local_mounts or []

--- a/executor/app/core/memory.py
+++ b/executor/app/core/memory.py
@@ -18,17 +18,26 @@ MEMORY_MCP_SERVER_KEY = "__poco_memory"
 class MemoryClient:
     """Client for manager memory proxy APIs."""
 
-    def __init__(self, base_url: str, session_id: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        session_id: str,
+        callback_token: str = "",
+        timeout: float = 10.0,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session_id = session_id
+        self.callback_token = callback_token
         self.timeout = timeout
 
-    @staticmethod
-    def _trace_headers() -> dict[str, str]:
-        return {
+    def _headers(self) -> dict[str, str]:
+        headers = {
             "X-Request-ID": get_request_id() or generate_request_id(),
             "X-Trace-ID": get_trace_id() or generate_trace_id(),
         }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
 
     async def _request(
         self,
@@ -44,7 +53,7 @@ class MemoryClient:
                 url=f"{self.base_url}{path}",
                 params=params,
                 json=json_body,
-                headers=self._trace_headers(),
+                headers=self._headers(),
             )
             response.raise_for_status()
 

--- a/executor/app/core/user_input.py
+++ b/executor/app/core/user_input.py
@@ -16,10 +16,12 @@ class UserInputClient:
     def __init__(
         self,
         base_url: str,
+        callback_token: str = "",
         timeout: float = 10.0,
         poll_interval: float = 0.5,
     ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.callback_token = callback_token
         self.timeout = timeout
         self.poll_interval = poll_interval
 
@@ -31,15 +33,21 @@ class UserInputClient:
             return callback_url[: -len("/api/v1/callback")]
         return callback_url.rstrip("/")
 
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "X-Request-ID": get_request_id() or generate_request_id(),
+            "X-Trace-ID": get_trace_id() or generate_trace_id(),
+        }
+        if self.callback_token:
+            headers["Authorization"] = f"Bearer {self.callback_token}"
+        return headers
+
     async def create_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.base_url}/api/v1/user-input-requests",
                 json=payload,
-                headers={
-                    "X-Request-ID": get_request_id() or generate_request_id(),
-                    "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                },
+                headers=self._headers(),
             )
             response.raise_for_status()
             data = response.json()
@@ -49,10 +57,7 @@ class UserInputClient:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.get(
                 f"{self.base_url}/api/v1/user-input-requests/{request_id}",
-                headers={
-                    "X-Request-ID": get_request_id() or generate_request_id(),
-                    "X-Trace-ID": get_trace_id() or generate_trace_id(),
-                },
+                headers=self._headers(),
             )
             response.raise_for_status()
             data = response.json()

--- a/executor/app/schemas/request.py
+++ b/executor/app/schemas/request.py
@@ -86,6 +86,8 @@ class TaskConfig(BaseModel):
     mount_fingerprint: str | None = None
     resolved_local_mounts: list[ResolvedLocalMount] = Field(default_factory=list)
     input_files: list[InputFile] = Field(default_factory=list)
+    file_references: list[dict[str, Any]] = Field(default_factory=list)
+    input_file_references: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class TaskRun(BaseModel):

--- a/executor/tests/test_engine_input_hint.py
+++ b/executor/tests/test_engine_input_hint.py
@@ -39,15 +39,11 @@ class AgentExecutorInputHintTests(unittest.TestCase):
 
         self.assertIsNotNone(hint)
         assert hint is not None
-        self.assertIn(
-            "Input files for this run are available under inputs/", hint
-        )
+        self.assertIn("Input files for this run are available under inputs/", hint)
         self.assertIn("Referenced files in the user prompt resolve to:", hint)
         self.assertIn("- #report.md -> inputs/report.md", hint)
         self.assertIn("- #agent.md -> /workspace/notes/agent.md", hint)
-        self.assertIn(
-            "Use /workspace paths for workspace file references", hint
-        )
+        self.assertIn("Use /workspace paths for workspace file references", hint)
         self.assertNotIn("#agent.md -> inputs/notes/agent.md", hint)
 
 

--- a/executor/tests/test_engine_input_hint.py
+++ b/executor/tests/test_engine_input_hint.py
@@ -5,7 +5,7 @@ from app.schemas.request import InputFile, TaskConfig
 
 
 class AgentExecutorInputHintTests(unittest.TestCase):
-    def test_build_input_hint_maps_file_references_to_staged_inputs(self) -> None:
+    def test_build_input_hint_maps_reference_kinds_to_runtime_paths(self) -> None:
         executor = AgentExecutor.__new__(AgentExecutor)
 
         hint = executor._build_input_hint(
@@ -15,11 +15,6 @@ class AgentExecutorInputHintTests(unittest.TestCase):
                         name="report.md",
                         source="uploads/session/report.md",
                         path="/inputs/report.md",
-                    ),
-                    InputFile(
-                        name="agent.md",
-                        source="workspace/session/notes/agent.md",
-                        path="/inputs/notes/agent.md",
                     ),
                 ],
                 file_references=[
@@ -49,7 +44,11 @@ class AgentExecutorInputHintTests(unittest.TestCase):
         )
         self.assertIn("Referenced files in the user prompt resolve to:", hint)
         self.assertIn("- #report.md -> inputs/report.md", hint)
-        self.assertIn("- #agent.md -> inputs/notes/agent.md", hint)
+        self.assertIn("- #agent.md -> /workspace/notes/agent.md", hint)
+        self.assertIn(
+            "Use /workspace paths for workspace file references", hint
+        )
+        self.assertNotIn("#agent.md -> inputs/notes/agent.md", hint)
 
 
 if __name__ == "__main__":

--- a/executor/tests/test_engine_input_hint.py
+++ b/executor/tests/test_engine_input_hint.py
@@ -1,0 +1,56 @@
+import unittest
+
+from app.core.engine import AgentExecutor
+from app.schemas.request import InputFile, TaskConfig
+
+
+class AgentExecutorInputHintTests(unittest.TestCase):
+    def test_build_input_hint_maps_file_references_to_staged_inputs(self) -> None:
+        executor = AgentExecutor.__new__(AgentExecutor)
+
+        hint = executor._build_input_hint(
+            TaskConfig(
+                input_files=[
+                    InputFile(
+                        name="report.md",
+                        source="uploads/session/report.md",
+                        path="/inputs/report.md",
+                    ),
+                    InputFile(
+                        name="agent.md",
+                        source="workspace/session/notes/agent.md",
+                        path="/inputs/notes/agent.md",
+                    ),
+                ],
+                file_references=[
+                    {
+                        "id": "uploads/session/report.md:4:14",
+                        "kind": "input_file",
+                        "source": "uploads/session/report.md",
+                        "insertedText": "#report.md",
+                        "displayName": "report.md",
+                    },
+                    {
+                        "id": "session-1:/notes/agent.md:19:28",
+                        "kind": "workspace_file",
+                        "sessionId": "session-1",
+                        "path": "/notes/agent.md",
+                        "insertedText": "#agent.md",
+                        "displayName": "agent.md",
+                    },
+                ],
+            )
+        )
+
+        self.assertIsNotNone(hint)
+        assert hint is not None
+        self.assertIn(
+            "Input files for this run are available under inputs/", hint
+        )
+        self.assertIn("Referenced files in the user prompt resolve to:", hint)
+        self.assertIn("- #report.md -> inputs/report.md", hint)
+        self.assertIn("- #agent.md -> inputs/notes/agent.md", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor/tests/test_manager_auth_clients.py
+++ b/executor/tests/test_manager_auth_clients.py
@@ -126,21 +126,21 @@ class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
         from app.schemas.request import TaskConfig, TaskRun
 
         background_tasks = MagicMock()
-        created_clients: dict[str, object] = {}
+        created_clients: dict[str, dict[str, object]] = {}
 
-        def callback_factory(**kwargs):
+        def callback_factory(**kwargs: object):
             created_clients["callback"] = kwargs
             return AsyncMock()
 
-        def user_input_factory(**kwargs):
+        def user_input_factory(**kwargs: object):
             created_clients["user_input"] = kwargs
             return AsyncMock()
 
-        def computer_factory(**kwargs):
+        def computer_factory(**kwargs: object):
             created_clients["computer"] = kwargs
             return AsyncMock()
 
-        def memory_factory(**kwargs):
+        def memory_factory(**kwargs: object):
             created_clients["memory"] = kwargs
             return AsyncMock()
 
@@ -167,7 +167,9 @@ class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result["status"], "accepted")
         self.assertEqual(created_clients["callback"]["callback_token"], CALLBACK_TOKEN)
-        self.assertEqual(created_clients["user_input"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(
+            created_clients["user_input"]["callback_token"], CALLBACK_TOKEN
+        )
         self.assertEqual(created_clients["computer"]["callback_token"], CALLBACK_TOKEN)
         self.assertEqual(created_clients["memory"]["callback_token"], CALLBACK_TOKEN)
 

--- a/executor/tests/test_manager_auth_clients.py
+++ b/executor/tests/test_manager_auth_clients.py
@@ -1,0 +1,176 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from app.core.callback import CallbackClient
+from app.core.channel_runtime import ChannelRuntimeClient
+from app.core.memory import MemoryClient
+from app.core.user_input import UserInputClient
+from app.schemas.callback import AgentCallbackRequest, CallbackStatus
+
+
+CALLBACK_TOKEN = "callback-token"
+
+
+class FakeAsyncClient:
+    requests: list[dict]
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.__class__.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    async def post(self, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": "POST", "url": url, **kwargs})
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+    async def get(self, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": "GET", "url": url, **kwargs})
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+    async def request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        self.__class__.requests.append({"method": method, "url": url, **kwargs})
+        request = httpx.Request(method, url)
+        return httpx.Response(200, json={"code": 0, "data": {}}, request=request)
+
+
+class ManagerAuthClientTests(unittest.IsolatedAsyncioTestCase):
+    def assertBearerHeader(self, request: dict) -> None:
+        self.assertEqual(
+            request["headers"]["Authorization"],
+            f"Bearer {CALLBACK_TOKEN}",
+        )
+
+    async def test_callback_client_sends_callback_token(self) -> None:
+        client = CallbackClient(
+            callback_url="http://manager/api/v1/callback",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.callback.httpx.AsyncClient", FakeAsyncClient):
+            sent = await client.send(
+                AgentCallbackRequest(
+                    session_id="session-1",
+                    status=CallbackStatus.RUNNING,
+                    progress=10,
+                )
+            )
+
+        self.assertTrue(sent)
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_memory_client_sends_callback_token(self) -> None:
+        client = MemoryClient(
+            base_url="http://manager",
+            session_id="session-1",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.memory.httpx.AsyncClient", FakeAsyncClient):
+            await client.list_memories()
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_channel_runtime_client_sends_callback_token(self) -> None:
+        client = ChannelRuntimeClient(
+            base_url="http://manager",
+            session_id="session-1",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.channel_runtime.httpx.AsyncClient", FakeAsyncClient):
+            await client.list_agents()
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_user_input_client_sends_callback_token(self) -> None:
+        client = UserInputClient(
+            base_url="http://manager",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.user_input.httpx.AsyncClient", FakeAsyncClient):
+            await client.get_request("request-1")
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+    async def test_computer_client_sends_callback_token(self) -> None:
+        from app.core.computer import ComputerClient
+
+        client = ComputerClient(
+            base_url="http://manager",
+            callback_token=CALLBACK_TOKEN,
+        )
+
+        with patch("app.core.computer.httpx.AsyncClient", FakeAsyncClient):
+            await client.upload_browser_screenshot(
+                session_id="session-1",
+                run_id=None,
+                tool_use_id="tool-1",
+                png_bytes=b"data",
+            )
+
+        self.assertBearerHeader(FakeAsyncClient.requests[0])
+
+
+class RunTaskClientWiringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_task_passes_callback_token_to_manager_clients(self) -> None:
+        from app.api.v1.task import run_task
+        from app.schemas.request import TaskConfig, TaskRun
+
+        background_tasks = MagicMock()
+        created_clients: dict[str, object] = {}
+
+        def callback_factory(**kwargs):
+            created_clients["callback"] = kwargs
+            return AsyncMock()
+
+        def user_input_factory(**kwargs):
+            created_clients["user_input"] = kwargs
+            return AsyncMock()
+
+        def computer_factory(**kwargs):
+            created_clients["computer"] = kwargs
+            return AsyncMock()
+
+        def memory_factory(**kwargs):
+            created_clients["memory"] = kwargs
+            return AsyncMock()
+
+        with (
+            patch("app.api.v1.task.CallbackClient", side_effect=callback_factory),
+            patch("app.api.v1.task.UserInputClient", side_effect=user_input_factory),
+            patch("app.api.v1.task.ComputerClient", side_effect=computer_factory),
+            patch("app.api.v1.task.MemoryClient", side_effect=memory_factory),
+            patch("app.api.v1.task.AgentExecutor"),
+            patch("app.api.v1.task.CallbackHook"),
+            patch("app.api.v1.task.BrowserScreenshotHook"),
+        ):
+            result = await run_task(
+                TaskRun(
+                    session_id="session-1",
+                    prompt="hello",
+                    callback_url="http://manager/api/v1/callback",
+                    callback_base_url="http://manager",
+                    callback_token=CALLBACK_TOKEN,
+                    config=TaskConfig(memory_enabled=True, browser_enabled=True),
+                ),
+                background_tasks,
+            )
+
+        self.assertEqual(result["status"], "accepted")
+        self.assertEqual(created_clients["callback"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["user_input"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["computer"]["callback_token"], CALLBACK_TOKEN)
+        self.assertEqual(created_clients["memory"]["callback_token"], CALLBACK_TOKEN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/app/api/v1/agent_channel_artifacts.py
+++ b/executor_manager/app/api/v1/agent_channel_artifacts.py
@@ -1,13 +1,18 @@
 from typing import Any
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse, Response as FastAPIResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/agent-channel-artifacts", tags=["agent-channel-artifacts"])
+router = APIRouter(
+    prefix="/agent-channel-artifacts",
+    tags=["agent-channel-artifacts"],
+    dependencies=[Depends(require_callback_token)],
+)
 backend_client = BackendClient()
 
 

--- a/executor_manager/app/api/v1/agent_channel_runtime.py
+++ b/executor_manager/app/api/v1/agent_channel_runtime.py
@@ -1,14 +1,16 @@
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
 router = APIRouter(
     prefix="/agent-channel-runtime",
     tags=["agent-channel-runtime"],
+    dependencies=[Depends(require_callback_token)],
 )
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/agent_channel_tasks.py
+++ b/executor_manager/app/api/v1/agent_channel_tasks.py
@@ -1,12 +1,17 @@
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/agent-channel-tasks", tags=["agent-channel-tasks"])
+router = APIRouter(
+    prefix="/agent-channel-tasks",
+    tags=["agent-channel-tasks"],
+    dependencies=[Depends(require_callback_token)],
+)
 backend_client = BackendClient()
 
 

--- a/executor_manager/app/api/v1/callback.py
+++ b/executor_manager/app/api/v1/callback.py
@@ -1,15 +1,20 @@
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.callback import AgentCallbackRequest, CallbackReceiveResponse
 from app.schemas.response import Response, ResponseSchema
 from app.services.callback_service import CallbackService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/callback", tags=["callback"])
+router = APIRouter(
+    prefix="/callback",
+    tags=["callback"],
+    dependencies=[Depends(require_callback_token)],
+)
 callback_service = CallbackService()
 
 

--- a/executor_manager/app/api/v1/computer.py
+++ b/executor_manager/app/api/v1/computer.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter, File, Form, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 
+from app.core.deps import require_callback_token
 from app.schemas.computer import ComputerScreenshotUploadResponse
 from app.schemas.response import Response, ResponseSchema
 from app.services.computer_service import ComputerService
 
-router = APIRouter(prefix="/computer", tags=["computer"])
+router = APIRouter(
+    prefix="/computer",
+    tags=["computer"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 computer_service = ComputerService()
 

--- a/executor_manager/app/api/v1/executor.py
+++ b/executor_manager/app/api/v1/executor.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.task import (
     ContainerDeleteRequest,
@@ -10,7 +11,11 @@ from app.schemas.task import (
 )
 from app.scheduler.task_dispatcher import TaskDispatcher
 
-router = APIRouter(prefix="/executor", tags=["executor"])
+router = APIRouter(
+    prefix="/executor",
+    tags=["executor"],
+    dependencies=[Depends(require_internal_token)],
+)
 
 
 @router.post("/cancel", response_model=ResponseSchema[TaskCancelResult])

--- a/executor_manager/app/api/v1/memories.py
+++ b/executor_manager/app/api/v1/memories.py
@@ -1,8 +1,9 @@
 from typing import Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.memory import (
     MemoryCreateJobEnqueueResponse,
     MemoryCreateJobResponse,
@@ -13,7 +14,11 @@ from app.schemas.memory import (
 from app.schemas.response import Response, ResponseSchema
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/memories", tags=["memories"])
+router = APIRouter(
+    prefix="/memories",
+    tags=["memories"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/schedules.py
+++ b/executor_manager/app/api/v1/schedules.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.core.settings import get_settings
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.schedule import (
@@ -17,7 +18,11 @@ from app.scheduler.pull_schedule_config import (
 from app.scheduler.pull_schedule_state import get_current_pull_schedule_config
 from app.scheduler.scheduler_config import scheduler
 
-router = APIRouter(prefix="/schedules", tags=["schedules"])
+router = APIRouter(
+    prefix="/schedules",
+    tags=["schedules"],
+    dependencies=[Depends(require_internal_token)],
+)
 
 
 def _build_job_info(job_id: str) -> ScheduleJobInfo | None:

--- a/executor_manager/app/api/v1/tasks.py
+++ b/executor_manager/app/api/v1/tasks.py
@@ -1,8 +1,9 @@
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.task import (
     SessionStatusResponse,
@@ -14,7 +15,11 @@ from app.services.task_service import TaskService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/tasks", tags=["tasks"])
+router = APIRouter(
+    prefix="/tasks",
+    tags=["tasks"],
+    dependencies=[Depends(require_internal_token)],
+)
 task_service = TaskService()
 
 

--- a/executor_manager/app/api/v1/user_input_requests.py
+++ b/executor_manager/app/api/v1/user_input_requests.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_callback_token
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.user_input_request import (
     UserInputRequestCreateRequest,
@@ -8,7 +9,11 @@ from app.schemas.user_input_request import (
 )
 from app.services.backend_client import BackendClient
 
-router = APIRouter(prefix="/user-input-requests", tags=["user-input-requests"])
+router = APIRouter(
+    prefix="/user-input-requests",
+    tags=["user-input-requests"],
+    dependencies=[Depends(require_callback_token)],
+)
 
 backend_client = BackendClient()
 

--- a/executor_manager/app/api/v1/workspace.py
+++ b/executor_manager/app/api/v1/workspace.py
@@ -1,14 +1,19 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
 from fastapi.responses import JSONResponse
 
+from app.core.deps import require_internal_token
 from app.core.errors.error_codes import ErrorCode
 from app.core.errors.exceptions import AppException
 from app.schemas.response import Response, ResponseSchema
 from app.schemas.workspace import FileNode
 from app.services.workspace_manager import WorkspaceManager
 
-router = APIRouter(prefix="/workspace", tags=["workspace"])
+router = APIRouter(
+    prefix="/workspace",
+    tags=["workspace"],
+    dependencies=[Depends(require_internal_token)],
+)
 workspace_manager = WorkspaceManager()
 
 

--- a/executor_manager/app/schemas/task.py
+++ b/executor_manager/app/schemas/task.py
@@ -59,6 +59,8 @@ class TaskConfig(BaseModel):
     filesystem_mode: FilesystemMode = "sandbox"
     local_mounts: list[LocalMountConfig] = Field(default_factory=list)
     input_files: list[InputFile] = Field(default_factory=list)
+    file_references: list[dict[str, Any]] = Field(default_factory=list)
+    input_file_references: list[dict[str, Any]] = Field(default_factory=list)
     user_id: str = ""
     container_mode: Literal["ephemeral", "persistent"] = "ephemeral"
     container_id: str | None = None

--- a/executor_manager/tests/test_agent_channel_artifacts_api.py
+++ b/executor_manager/tests/test_agent_channel_artifacts_api.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 from fastapi import FastAPI
@@ -9,7 +9,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_artifacts import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelArtifactsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_read_artifact_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -25,6 +37,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "artifact_id": "artifact-1",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -66,6 +79,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "logical_path": "Harness 工程核心指南.md",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(result.status_code, 404)
@@ -89,6 +103,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "artifact_id": "artifact-1",
                     "max_chars": 2000,
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -118,6 +133,7 @@ class AgentChannelArtifactsApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "artifact_id": "artifact-1",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_agent_channel_runtime_api.py
+++ b/executor_manager/tests/test_agent_channel_runtime_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -7,7 +7,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_runtime import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelRuntimeApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_read_messages_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -22,6 +34,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "session_id": "session-1",
                     "message_ids": ["message-1"],
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -41,6 +54,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-runtime/agents/list",
                 json={"session_id": "session-1"},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -61,6 +75,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "agent_handle": "api",
                     "request_text": "Please review this.",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -87,6 +102,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "message_id": "message-1",
                     "emoji": "👍",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -110,6 +126,7 @@ class AgentChannelRuntimeApiTests(unittest.TestCase):
                     "message_id": "message-1",
                     "emoji": "✅",
                 },
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_agent_channel_tasks_api.py
+++ b/executor_manager/tests/test_agent_channel_tasks_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -7,7 +7,19 @@ from fastapi.testclient import TestClient
 from app.api.v1.agent_channel_tasks import router
 
 
+CALLBACK_TOKEN = "callback-token"
+CALLBACK_HEADERS = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+
 class AgentChannelTasksApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._settings_patch = patch(
+            "app.core.deps.get_settings",
+            return_value=MagicMock(callback_token=CALLBACK_TOKEN),
+        )
+        self._settings_patch.start()
+        self.addCleanup(self._settings_patch.stop)
+
     def test_list_tasks_proxies_session_payload(self) -> None:
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
@@ -19,6 +31,7 @@ class AgentChannelTasksApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-tasks/list",
                 json={"session_id": "session-1", "status": "todo", "limit": 20},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)
@@ -38,6 +51,7 @@ class AgentChannelTasksApiTests(unittest.TestCase):
             response = TestClient(app).post(
                 "/api/v1/agent-channel-tasks/read",
                 json={"session_id": "session-1", "task_id": "task-1"},
+                headers=CALLBACK_HEADERS,
             )
 
         self.assertEqual(response.status_code, 200)

--- a/executor_manager/tests/test_control_plane_auth.py
+++ b/executor_manager/tests/test_control_plane_auth.py
@@ -1,0 +1,194 @@
+import unittest
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import executor, schedules, tasks, workspace
+
+
+INTERNAL_TOKEN = "internal-token"
+
+
+class ExecutorManagerControlPlaneAuthTests(unittest.TestCase):
+    def _app(self) -> FastAPI:
+        app = FastAPI()
+        app.include_router(workspace.router, prefix="/api/v1")
+        app.include_router(tasks.router, prefix="/api/v1")
+        app.include_router(executor.router, prefix="/api/v1")
+        app.include_router(schedules.router, prefix="/api/v1")
+
+        @app.get("/api/v1/health")
+        async def health() -> dict[str, str]:
+            return {"status": "healthy"}
+
+        return app
+
+    def _settings(self) -> MagicMock:
+        return MagicMock(
+            internal_api_token=INTERNAL_TOKEN,
+            schedule_config_path=None,
+        )
+
+    @contextmanager
+    def _with_common_patches(self) -> Iterator[None]:
+        task_response = SimpleNamespace(
+            model_dump=lambda: {
+                "task_id": "task-1",
+                "session_id": "session-1",
+                "status": "scheduled",
+            }
+        )
+        pool = MagicMock()
+        pool.delete_container = AsyncMock()
+        pool.get_container_stats.return_value = {
+            "total_active": 0,
+            "persistent_containers": 0,
+            "ephemeral_containers": 0,
+            "containers": [],
+        }
+        schedule_config = SimpleNamespace(enabled=True, rules=[])
+        patchers = [
+            patch("app.core.deps.get_settings", return_value=self._settings()),
+            patch(
+                "app.api.v1.workspace.workspace_manager.list_workspace_files",
+                return_value=[],
+            ),
+            patch(
+                "app.api.v1.workspace.workspace_manager.delete_workspace",
+                return_value=True,
+            ),
+            patch(
+                "app.api.v1.tasks.task_service.create_task",
+                new=AsyncMock(return_value=task_response),
+            ),
+            patch(
+                "app.api.v1.executor.TaskDispatcher.get_container_pool",
+                return_value=pool,
+            ),
+            patch(
+                "app.api.v1.schedules.get_current_pull_schedule_config",
+                return_value=schedule_config,
+            ),
+        ]
+        with ExitStack() as stack:
+            tmp_dir = stack.enter_context(TemporaryDirectory())
+            preview_file = Path(tmp_dir) / "secret.txt"
+            preview_file.write_text("secret", encoding="utf-8")
+            stack.enter_context(
+                patch(
+                    "app.api.v1.workspace.workspace_manager.resolve_workspace_file",
+                    return_value=preview_file,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "app.api.v1.workspace.workspace_manager.archive_workspace",
+                    return_value=str(preview_file),
+                )
+            )
+            for patcher in patchers:
+                stack.enter_context(patcher)
+            yield
+
+    def test_control_plane_routes_reject_missing_internal_token(self) -> None:
+        client = TestClient(self._app())
+        requests = [
+            (
+                "GET",
+                "/api/v1/workspace/file/victim/session-1?path=secret.txt",
+                None,
+            ),
+            ("GET", "/api/v1/workspace/files/victim/session-1", None),
+            ("POST", "/api/v1/workspace/archive/victim/session-1", None),
+            ("DELETE", "/api/v1/workspace/victim/session-1", None),
+            (
+                "POST",
+                "/api/v1/tasks",
+                {
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+            ),
+            ("POST", "/api/v1/executor/delete", {"container_id": "container-1"}),
+            ("GET", "/api/v1/executor/load", None),
+            ("GET", "/api/v1/schedules", None),
+        ]
+
+        with self._with_common_patches():
+            for method, path, body in requests:
+                with self.subTest(path=path):
+                    response = client.request(method, path, json=body)
+                    self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_reject_wrong_internal_token(self) -> None:
+        client = TestClient(self._app())
+
+        with self._with_common_patches():
+            response = client.get(
+                "/api/v1/workspace/files/victim/session-1",
+                headers={"X-Internal-Token": "wrong-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_reject_callback_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"Authorization": "Bearer callback-token"}
+
+        with self._with_common_patches():
+            response = client.post(
+                "/api/v1/tasks",
+                json={
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+                headers=headers,
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_control_plane_routes_accept_valid_internal_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"X-Internal-Token": INTERNAL_TOKEN}
+
+        with self._with_common_patches():
+            workspace_response = client.get(
+                "/api/v1/workspace/files/victim/session-1",
+                headers=headers,
+            )
+            task_response = client.post(
+                "/api/v1/tasks",
+                json={
+                    "prompt": "hello",
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                    "config": {},
+                },
+                headers=headers,
+            )
+            executor_response = client.get("/api/v1/executor/load", headers=headers)
+            schedules_response = client.get("/api/v1/schedules", headers=headers)
+
+        self.assertEqual(workspace_response.status_code, 200)
+        self.assertEqual(task_response.status_code, 200)
+        self.assertEqual(executor_response.status_code, 200)
+        self.assertEqual(schedules_response.status_code, 200)
+
+    def test_health_route_stays_public(self) -> None:
+        response = TestClient(self._app()).get("/api/v1/health")
+
+        self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/tests/test_executor_proxy_auth.py
+++ b/executor_manager/tests/test_executor_proxy_auth.py
@@ -1,0 +1,234 @@
+import unittest
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1 import (
+    agent_channel_artifacts,
+    agent_channel_runtime,
+    agent_channel_tasks,
+    callback,
+    computer,
+    memories,
+    user_input_requests,
+)
+from app.schemas.callback import CallbackReceiveResponse, CallbackStatus
+from app.schemas.computer import ComputerScreenshotUploadResponse
+
+
+CALLBACK_TOKEN = "callback-token"
+
+
+class ExecutorManagerProxyAuthTests(unittest.TestCase):
+    def _app(self) -> FastAPI:
+        app = FastAPI()
+        app.include_router(callback.router, prefix="/api/v1")
+        app.include_router(computer.router, prefix="/api/v1")
+        app.include_router(memories.router, prefix="/api/v1")
+        app.include_router(agent_channel_runtime.router, prefix="/api/v1")
+        app.include_router(agent_channel_artifacts.router, prefix="/api/v1")
+        app.include_router(agent_channel_tasks.router, prefix="/api/v1")
+        app.include_router(user_input_requests.router, prefix="/api/v1")
+        return app
+
+    def _settings(self) -> MagicMock:
+        return MagicMock(callback_token=CALLBACK_TOKEN)
+
+    def _user_input_payload(self) -> dict[str, object]:
+        now = datetime.now(timezone.utc).isoformat()
+        return {
+            "id": "request-1",
+            "session_id": "session-1",
+            "tool_name": "ask_user",
+            "tool_input": {},
+            "status": "pending",
+            "answers": None,
+            "expires_at": now,
+            "answered_at": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    @contextmanager
+    def _with_common_patches(self) -> Iterator[None]:
+        callback_response = CallbackReceiveResponse(
+            status="received",
+            session_id="session-1",
+            callback_status=CallbackStatus.RUNNING,
+            progress=10,
+        )
+        screenshot_response = ComputerScreenshotUploadResponse(
+            session_id="session-1",
+            run_id=None,
+            tool_use_id="tool-1",
+            key="screenshots/session-1/tool-1.png",
+            content_type="image/png",
+            size_bytes=4,
+        )
+        patchers = [
+            patch("app.core.deps.get_settings", return_value=self._settings()),
+            patch(
+                "app.api.v1.callback.callback_service.process_callback",
+                new=AsyncMock(return_value=callback_response),
+            ),
+            patch(
+                "app.api.v1.computer.computer_service.upload_browser_screenshot",
+                return_value=screenshot_response,
+            ),
+            patch(
+                "app.api.v1.memories.backend_client.create_memory",
+                new=AsyncMock(return_value={"job_id": "job-1", "status": "queued"}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_runtime."
+                "backend_client.read_agent_channel_messages",
+                new=AsyncMock(return_value={"messages": []}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_artifacts."
+                "backend_client.list_agent_channel_artifacts",
+                new=AsyncMock(return_value={"artifacts": []}),
+            ),
+            patch(
+                "app.api.v1.agent_channel_tasks.backend_client.list_agent_channel_tasks",
+                new=AsyncMock(return_value={"tasks": []}),
+            ),
+            patch(
+                "app.api.v1.user_input_requests."
+                "backend_client.create_user_input_request",
+                new=AsyncMock(return_value=self._user_input_payload()),
+            ),
+        ]
+        with ExitStack() as stack:
+            for patcher in patchers:
+                stack.enter_context(patcher)
+            yield
+
+    def test_proxy_routes_reject_missing_callback_token(self) -> None:
+        client = TestClient(self._app())
+        requests = [
+            (
+                "POST",
+                "/api/v1/callback",
+                {
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/computer/screenshots",
+                {
+                    "data": {
+                        "session_id": "session-1",
+                        "tool_use_id": "tool-1",
+                    },
+                    "files": {"file": ("screenshot.png", b"data", "image/png")},
+                },
+                "multipart",
+            ),
+            (
+                "POST",
+                "/api/v1/memories",
+                {
+                    "session_id": "session-1",
+                    "messages": [{"role": "user", "content": "remember this"}],
+                },
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-runtime/messages/read",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-artifacts/list",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/agent-channel-tasks/list",
+                {"session_id": "session-1"},
+                None,
+            ),
+            (
+                "POST",
+                "/api/v1/user-input-requests",
+                {
+                    "session_id": "session-1",
+                    "tool_name": "ask_user",
+                    "tool_input": {},
+                },
+                None,
+            ),
+        ]
+
+        with self._with_common_patches():
+            for method, path, body, mode in requests:
+                with self.subTest(path=path):
+                    if mode == "multipart":
+                        response = client.request(method, path, **body)
+                    else:
+                        response = client.request(method, path, json=body)
+                    self.assertEqual(response.status_code, 403)
+
+    def test_proxy_routes_reject_internal_token_as_callback_token(self) -> None:
+        client = TestClient(self._app())
+
+        with self._with_common_patches():
+            response = client.post(
+                "/api/v1/callback",
+                json={
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                headers={"Authorization": "Bearer internal-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_proxy_routes_accept_valid_callback_token(self) -> None:
+        client = TestClient(self._app())
+        headers = {"Authorization": f"Bearer {CALLBACK_TOKEN}"}
+
+        with self._with_common_patches():
+            callback_response = client.post(
+                "/api/v1/callback",
+                json={
+                    "session_id": "session-1",
+                    "status": "running",
+                    "progress": 10,
+                },
+                headers=headers,
+            )
+            memory_response = client.post(
+                "/api/v1/memories",
+                json={
+                    "session_id": "session-1",
+                    "messages": [{"role": "user", "content": "remember this"}],
+                },
+                headers=headers,
+            )
+            channel_response = client.post(
+                "/api/v1/agent-channel-runtime/messages/read",
+                json={"session_id": "session-1"},
+                headers=headers,
+            )
+
+        self.assertEqual(callback_response.status_code, 200)
+        self.assertEqual(memory_response.status_code, 200)
+        self.assertEqual(channel_response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/executor_manager/tests/test_executor_proxy_auth.py
+++ b/executor_manager/tests/test_executor_proxy_auth.py
@@ -123,18 +123,6 @@ class ExecutorManagerProxyAuthTests(unittest.TestCase):
             ),
             (
                 "POST",
-                "/api/v1/computer/screenshots",
-                {
-                    "data": {
-                        "session_id": "session-1",
-                        "tool_use_id": "tool-1",
-                    },
-                    "files": {"file": ("screenshot.png", b"data", "image/png")},
-                },
-                "multipart",
-            ),
-            (
-                "POST",
                 "/api/v1/memories",
                 {
                     "session_id": "session-1",
@@ -175,11 +163,19 @@ class ExecutorManagerProxyAuthTests(unittest.TestCase):
         with self._with_common_patches():
             for method, path, body, mode in requests:
                 with self.subTest(path=path):
-                    if mode == "multipart":
-                        response = client.request(method, path, **body)
-                    else:
-                        response = client.request(method, path, json=body)
+                    response = client.request(method, path, json=body)
                     self.assertEqual(response.status_code, 403)
+            with self.subTest(path="/api/v1/computer/screenshots"):
+                response = client.request(
+                    "POST",
+                    "/api/v1/computer/screenshots",
+                    data={
+                        "session_id": "session-1",
+                        "tool_use_id": "tool-1",
+                    },
+                    files={"file": ("screenshot.png", b"data", "image/png")},
+                )
+                self.assertEqual(response.status_code, 403)
 
     def test_proxy_routes_reject_internal_token_as_callback_token(self) -> None:
         client = TestClient(self._app())

--- a/frontend/features/chat/actions/session-actions.ts
+++ b/frontend/features/chat/actions/session-actions.ts
@@ -23,6 +23,30 @@ const inputFileSchema = z
   })
   .passthrough();
 
+const inputFileReferenceSchema = z
+  .object({
+    id: z.string().trim().min(1),
+    kind: z.literal("input_file"),
+    source: z.string().trim().min(1),
+    insertedText: z.string().trim().min(1),
+    displayName: z.string().trim().min(1),
+    range: z
+      .object({
+        start: z.number().int().nonnegative(),
+        end: z.number().int().nonnegative(),
+      })
+      .optional(),
+    metadata: z
+      .object({
+        inputFileId: z.string().optional().nullable(),
+        size: z.number().optional().nullable(),
+        contentType: z.string().optional().nullable(),
+        path: z.string().optional().nullable(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
 const configSchema = z
   .object({
     repo_url: z.string().optional().nullable(),
@@ -63,6 +87,7 @@ const configSchema = z
       )
       .optional(),
     input_files: z.array(inputFileSchema).optional(),
+    input_file_references: z.array(inputFileReferenceSchema).optional(),
   })
   .passthrough();
 
@@ -115,6 +140,7 @@ const sendMessageSchema = z
     sessionId: z.string().trim().min(1, VALIDATION_ERRORS.missingSessionId),
     content: z.string(),
     attachments: z.array(inputFileSchema).optional(),
+    input_file_references: z.array(inputFileReferenceSchema).optional(),
     model: z.string().trim().optional().nullable(),
     model_provider_id: z.string().trim().optional().nullable(),
   })
@@ -137,6 +163,7 @@ const updateQueuedQuerySchema = queuedQueryItemSchema
   .extend({
     prompt: z.string().optional(),
     attachments: z.array(inputFileSchema).optional(),
+    input_file_references: z.array(inputFileReferenceSchema).optional(),
   })
   .refine(
     (data) => data.prompt !== undefined || data.attachments !== undefined,
@@ -217,8 +244,14 @@ export async function createSessionAction(input: CreateSessionInput) {
 }
 
 export async function sendMessageAction(input: SendMessageInput) {
-  const { sessionId, content, attachments, model, model_provider_id } =
-    sendMessageSchema.parse(input);
+  const {
+    sessionId,
+    content,
+    attachments,
+    input_file_references,
+    model,
+    model_provider_id,
+  } = sendMessageSchema.parse(input);
 
   // Ensure we have a prompt if content is empty but attachments exist
   const finalContent =
@@ -229,6 +262,7 @@ export async function sendMessageAction(input: SendMessageInput) {
     model,
     model_provider_id,
     attachments,
+    input_file_references,
     createClientRequestId(),
   );
   return mapTaskEnqueueResult(result);
@@ -367,11 +401,12 @@ export async function setSessionPinAction(input: SetSessionPinInput) {
 }
 
 export async function updateQueuedQueryAction(input: UpdateQueuedQueryInput) {
-  const { sessionId, itemId, prompt, attachments } =
+  const { sessionId, itemId, prompt, attachments, input_file_references } =
     updateQueuedQuerySchema.parse(input);
   return chatService.updateQueuedQuery(sessionId, itemId, {
     prompt,
     attachments,
+    input_file_references,
   });
 }
 

--- a/frontend/features/chat/actions/session-actions.ts
+++ b/frontend/features/chat/actions/session-actions.ts
@@ -47,6 +47,35 @@ const inputFileReferenceSchema = z
   })
   .passthrough();
 
+const workspaceFileReferenceSchema = z
+  .object({
+    id: z.string().trim().min(1),
+    kind: z.literal("workspace_file"),
+    sessionId: z.string().trim().min(1),
+    path: z.string().trim().min(1),
+    insertedText: z.string().trim().min(1),
+    displayName: z.string().trim().min(1),
+    range: z
+      .object({
+        start: z.number().int().nonnegative(),
+        end: z.number().int().nonnegative(),
+      })
+      .optional(),
+    metadata: z
+      .object({
+        size: z.number().optional().nullable(),
+        contentType: z.string().optional().nullable(),
+        sourceKind: z.string().optional().nullable(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+const fileReferenceSchema = z.discriminatedUnion("kind", [
+  inputFileReferenceSchema,
+  workspaceFileReferenceSchema,
+]);
+
 const configSchema = z
   .object({
     repo_url: z.string().optional().nullable(),
@@ -87,7 +116,8 @@ const configSchema = z
       )
       .optional(),
     input_files: z.array(inputFileSchema).optional(),
-    input_file_references: z.array(inputFileReferenceSchema).optional(),
+    file_references: z.array(fileReferenceSchema).optional(),
+    input_file_references: z.array(fileReferenceSchema).optional(),
   })
   .passthrough();
 
@@ -140,7 +170,8 @@ const sendMessageSchema = z
     sessionId: z.string().trim().min(1, VALIDATION_ERRORS.missingSessionId),
     content: z.string(),
     attachments: z.array(inputFileSchema).optional(),
-    input_file_references: z.array(inputFileReferenceSchema).optional(),
+    file_references: z.array(fileReferenceSchema).optional(),
+    input_file_references: z.array(fileReferenceSchema).optional(),
     model: z.string().trim().optional().nullable(),
     model_provider_id: z.string().trim().optional().nullable(),
   })
@@ -163,10 +194,15 @@ const updateQueuedQuerySchema = queuedQueryItemSchema
   .extend({
     prompt: z.string().optional(),
     attachments: z.array(inputFileSchema).optional(),
-    input_file_references: z.array(inputFileReferenceSchema).optional(),
+    file_references: z.array(fileReferenceSchema).optional(),
+    input_file_references: z.array(fileReferenceSchema).optional(),
   })
   .refine(
-    (data) => data.prompt !== undefined || data.attachments !== undefined,
+    (data) =>
+      data.prompt !== undefined ||
+      data.attachments !== undefined ||
+      data.file_references !== undefined ||
+      data.input_file_references !== undefined,
     {
       message: VALIDATION_ERRORS.messageContentRequired,
       path: ["prompt"],
@@ -248,11 +284,13 @@ export async function sendMessageAction(input: SendMessageInput) {
     sessionId,
     content,
     attachments,
+    file_references,
     input_file_references,
     model,
     model_provider_id,
   } = sendMessageSchema.parse(input);
 
+  const fileReferences = file_references ?? input_file_references;
   // Ensure we have a prompt if content is empty but attachments exist
   const finalContent =
     content.trim() || (attachments?.length ? "Uploaded files" : content);
@@ -262,7 +300,7 @@ export async function sendMessageAction(input: SendMessageInput) {
     model,
     model_provider_id,
     attachments,
-    input_file_references,
+    fileReferences,
     createClientRequestId(),
   );
   return mapTaskEnqueueResult(result);
@@ -401,12 +439,19 @@ export async function setSessionPinAction(input: SetSessionPinInput) {
 }
 
 export async function updateQueuedQueryAction(input: UpdateQueuedQueryInput) {
-  const { sessionId, itemId, prompt, attachments, input_file_references } =
-    updateQueuedQuerySchema.parse(input);
+  const {
+    sessionId,
+    itemId,
+    prompt,
+    attachments,
+    file_references,
+    input_file_references,
+  } = updateQueuedQuerySchema.parse(input);
+  const fileReferences = file_references ?? input_file_references;
   return chatService.updateQueuedQuery(sessionId, itemId, {
     prompt,
     attachments,
-    input_file_references,
+    file_references: fileReferences,
   });
 }
 

--- a/frontend/features/chat/api/chat-api.ts
+++ b/frontend/features/chat/api/chat-api.ts
@@ -223,7 +223,7 @@ export const chatService = {
     model?: string | null,
     modelProviderId?: string | null,
     attachments?: InputFile[],
-    inputFileReferences?: TaskConfig["input_file_references"],
+    fileReferences?: TaskConfig["file_references"],
     clientRequestId?: string,
   ): Promise<TaskEnqueueResponse> => {
     const normalizedModel = (model || "").trim() || undefined;
@@ -231,18 +231,16 @@ export const chatService = {
       (modelProviderId || "").trim() || undefined;
     const hasModelOverride = Boolean(normalizedModel);
     const hasAttachments = (attachments?.length ?? 0) > 0;
-    const hasInputFileReferences = (inputFileReferences?.length ?? 0) > 0;
+    const hasFileReferences = (fileReferences?.length ?? 0) > 0;
     const config: TaskConfig | undefined =
-      hasModelOverride || hasAttachments || hasInputFileReferences
+      hasModelOverride || hasAttachments || hasFileReferences
         ? {
             ...(hasModelOverride ? { model: normalizedModel } : {}),
             ...(hasModelOverride && normalizedModelProviderId
               ? { model_provider_id: normalizedModelProviderId }
               : {}),
             ...(hasAttachments ? { input_files: attachments } : {}),
-            ...(hasInputFileReferences
-              ? { input_file_references: inputFileReferences }
-              : {}),
+            ...(hasFileReferences ? { file_references: fileReferences } : {}),
           }
         : undefined;
 

--- a/frontend/features/chat/api/chat-api.ts
+++ b/frontend/features/chat/api/chat-api.ts
@@ -223,6 +223,7 @@ export const chatService = {
     model?: string | null,
     modelProviderId?: string | null,
     attachments?: InputFile[],
+    inputFileReferences?: TaskConfig["input_file_references"],
     clientRequestId?: string,
   ): Promise<TaskEnqueueResponse> => {
     const normalizedModel = (model || "").trim() || undefined;
@@ -230,14 +231,18 @@ export const chatService = {
       (modelProviderId || "").trim() || undefined;
     const hasModelOverride = Boolean(normalizedModel);
     const hasAttachments = (attachments?.length ?? 0) > 0;
+    const hasInputFileReferences = (inputFileReferences?.length ?? 0) > 0;
     const config: TaskConfig | undefined =
-      hasModelOverride || hasAttachments
+      hasModelOverride || hasAttachments || hasInputFileReferences
         ? {
             ...(hasModelOverride ? { model: normalizedModel } : {}),
             ...(hasModelOverride && normalizedModelProviderId
               ? { model_provider_id: normalizedModelProviderId }
               : {}),
             ...(hasAttachments ? { input_files: attachments } : {}),
+            ...(hasInputFileReferences
+              ? { input_file_references: inputFileReferences }
+              : {}),
           }
         : undefined;
 

--- a/frontend/features/chat/components/chat/chat-message-list.tsx
+++ b/frontend/features/chat/components/chat/chat-message-list.tsx
@@ -490,6 +490,7 @@ export function ChatMessageList({
                     messageId={message.id}
                     content={message.content}
                     triggerContext={message.metadata?.triggerContext}
+                    inputFileReferences={message.metadata?.inputFileReferences}
                     attachments={message.attachments}
                     repoUrl={message.id === firstUserMessageId ? repoUrl : null}
                     gitBranch={

--- a/frontend/features/chat/components/chat/chat-message-list.tsx
+++ b/frontend/features/chat/components/chat/chat-message-list.tsx
@@ -490,7 +490,10 @@ export function ChatMessageList({
                     messageId={message.id}
                     content={message.content}
                     triggerContext={message.metadata?.triggerContext}
-                    inputFileReferences={message.metadata?.inputFileReferences}
+                    fileReferences={
+                      message.metadata?.fileReferences ??
+                      message.metadata?.inputFileReferences
+                    }
                     attachments={message.attachments}
                     repoUrl={message.id === firstUserMessageId ? repoUrl : null}
                     gitBranch={

--- a/frontend/features/chat/components/chat/messages/user-message.tsx
+++ b/frontend/features/chat/components/chat/messages/user-message.tsx
@@ -7,6 +7,7 @@ import {
   ChevronUp,
   Copy,
   Check,
+  FileText,
   Pencil,
 } from "lucide-react";
 import { FileCard } from "@/components/shared/file-card";
@@ -15,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type {
   AgentTriggerContext,
+  ChatFileReference,
   MessageBlock,
   InputFile,
 } from "@/features/chat/types";
@@ -27,6 +29,7 @@ export function UserMessage({
   messageId,
   content,
   triggerContext,
+  inputFileReferences,
   attachments,
   repoUrl,
   gitBranch,
@@ -35,6 +38,7 @@ export function UserMessage({
   messageId: string;
   content: string | MessageBlock[];
   triggerContext?: AgentTriggerContext;
+  inputFileReferences?: ChatFileReference[];
   attachments?: InputFile[];
   repoUrl?: string | null;
   gitBranch?: string | null;
@@ -72,6 +76,9 @@ export function UserMessage({
   const trimmedGitBranch = (gitBranch || "").trim();
   const hasRepo = trimmedRepoUrl.length > 0;
   const hasAttachments = Boolean(attachments && attachments.length > 0);
+  const hasInputFileReferences = Boolean(
+    inputFileReferences && inputFileReferences.length > 0,
+  );
   const triggerContextRows = React.useMemo(
     () => buildTriggerContextRows(triggerContext, t),
     [triggerContext, t],
@@ -260,6 +267,25 @@ export function UserMessage({
                   ) : null}
                 </div>
               ) : null}
+              {hasInputFileReferences ? (
+                <div className="flex max-w-full flex-wrap justify-end gap-1.5">
+                  {inputFileReferences?.map((reference, index) => {
+                    const displayName = formatFileReferenceDisplay(reference);
+                    return (
+                      <span
+                        key={`${reference.id}:${index}`}
+                        className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border border-border bg-background/80 px-2 text-xs text-muted-foreground shadow-sm"
+                        title={formatFileReferenceTitle(reference)}
+                      >
+                        <FileText className="size-3.5 shrink-0" />
+                        <span className="min-w-0 max-w-48 truncate">
+                          {displayName}
+                        </span>
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : null}
               <div className="w-fit min-w-0 max-w-full overflow-hidden rounded-lg bg-muted px-4 py-2 text-foreground">
                 <p
                   ref={observerRef}
@@ -320,6 +346,23 @@ export function UserMessage({
       )}
     </div>
   );
+}
+
+function formatFileReferenceDisplay(reference: ChatFileReference): string {
+  const displayName = reference.displayName?.trim();
+  if (displayName) return displayName;
+  if (reference.kind === "workspace_file") {
+    return reference.path.split("/").filter(Boolean).pop() || reference.path;
+  }
+  return reference.metadata?.path || reference.source;
+}
+
+function formatFileReferenceTitle(reference: ChatFileReference): string {
+  const displayName = formatFileReferenceDisplay(reference);
+  if (reference.kind === "workspace_file") {
+    return reference.path || displayName;
+  }
+  return reference.metadata?.path || reference.source || displayName;
 }
 
 function formatTriggerSource(triggerContext?: AgentTriggerContext): string {

--- a/frontend/features/chat/components/chat/messages/user-message.tsx
+++ b/frontend/features/chat/components/chat/messages/user-message.tsx
@@ -401,7 +401,9 @@ function renderFileReferenceText(
 
   if (cursor < text.length) {
     nodes.push(
-      <React.Fragment key={`text-${cursor}`}>{text.slice(cursor)}</React.Fragment>,
+      <React.Fragment key={`text-${cursor}`}>
+        {text.slice(cursor)}
+      </React.Fragment>,
     );
   }
   return nodes;

--- a/frontend/features/chat/components/chat/messages/user-message.tsx
+++ b/frontend/features/chat/components/chat/messages/user-message.tsx
@@ -7,7 +7,6 @@ import {
   ChevronUp,
   Copy,
   Check,
-  FileText,
   Pencil,
 } from "lucide-react";
 import { FileCard } from "@/components/shared/file-card";
@@ -20,6 +19,7 @@ import type {
   MessageBlock,
   InputFile,
 } from "@/features/chat/types";
+import { getFileIcon } from "@/lib/utils/file/get-file-icon";
 import { useT } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
 
@@ -29,7 +29,7 @@ export function UserMessage({
   messageId,
   content,
   triggerContext,
-  inputFileReferences,
+  fileReferences,
   attachments,
   repoUrl,
   gitBranch,
@@ -38,7 +38,7 @@ export function UserMessage({
   messageId: string;
   content: string | MessageBlock[];
   triggerContext?: AgentTriggerContext;
-  inputFileReferences?: ChatFileReference[];
+  fileReferences?: ChatFileReference[];
   attachments?: InputFile[];
   repoUrl?: string | null;
   gitBranch?: string | null;
@@ -76,9 +76,6 @@ export function UserMessage({
   const trimmedGitBranch = (gitBranch || "").trim();
   const hasRepo = trimmedRepoUrl.length > 0;
   const hasAttachments = Boolean(attachments && attachments.length > 0);
-  const hasInputFileReferences = Boolean(
-    inputFileReferences && inputFileReferences.length > 0,
-  );
   const triggerContextRows = React.useMemo(
     () => buildTriggerContextRows(triggerContext, t),
     [triggerContext, t],
@@ -267,25 +264,6 @@ export function UserMessage({
                   ) : null}
                 </div>
               ) : null}
-              {hasInputFileReferences ? (
-                <div className="flex max-w-full flex-wrap justify-end gap-1.5">
-                  {inputFileReferences?.map((reference, index) => {
-                    const displayName = formatFileReferenceDisplay(reference);
-                    return (
-                      <span
-                        key={`${reference.id}:${index}`}
-                        className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border border-border bg-background/80 px-2 text-xs text-muted-foreground shadow-sm"
-                        title={formatFileReferenceTitle(reference)}
-                      >
-                        <FileText className="size-3.5 shrink-0" />
-                        <span className="min-w-0 max-w-48 truncate">
-                          {displayName}
-                        </span>
-                      </span>
-                    );
-                  })}
-                </div>
-              ) : null}
               <div className="w-fit min-w-0 max-w-full overflow-hidden rounded-lg bg-muted px-4 py-2 text-foreground">
                 <p
                   ref={observerRef}
@@ -293,7 +271,7 @@ export function UserMessage({
                     shouldCollapse && !isExpanded ? "line-clamp-5" : ""
                   }`}
                 >
-                  {textContent}
+                  {renderFileReferenceText(textContent, fileReferences ?? [])}
                 </p>
               </div>
               <div className="flex items-center justify-between w-full gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
@@ -363,6 +341,70 @@ function formatFileReferenceTitle(reference: ChatFileReference): string {
     return reference.path || displayName;
   }
   return reference.metadata?.path || reference.source || displayName;
+}
+
+function formatFileReferenceIconName(reference: ChatFileReference): string {
+  if (reference.kind === "workspace_file") {
+    return reference.path || reference.displayName;
+  }
+  return reference.metadata?.path || reference.displayName || reference.source;
+}
+
+function renderFileReferenceText(
+  text: string,
+  references: ChatFileReference[],
+): React.ReactNode[] | string {
+  if (references.length === 0) return text;
+
+  const positioned = references
+    .map((reference) => {
+      const rangeStart =
+        reference.range &&
+        text.slice(reference.range.start, reference.range.end) ===
+          reference.insertedText
+          ? reference.range.start
+          : text.indexOf(reference.insertedText);
+      return { reference, start: rangeStart };
+    })
+    .filter((item) => item.start >= 0)
+    .sort((left, right) => left.start - right.start);
+
+  if (positioned.length === 0) return text;
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  for (const item of positioned) {
+    if (item.start < cursor) continue;
+    if (item.start > cursor) {
+      nodes.push(
+        <React.Fragment key={`text-${cursor}`}>
+          {text.slice(cursor, item.start)}
+        </React.Fragment>,
+      );
+    }
+
+    const reference = item.reference;
+    const displayName = formatFileReferenceDisplay(reference);
+    const Icon = getFileIcon(formatFileReferenceIconName(reference));
+    nodes.push(
+      <span
+        key={`${reference.id}-${item.start}`}
+        title={formatFileReferenceTitle(reference)}
+        className="inline-flex max-w-full cursor-text select-text items-center rounded-md border border-amber-900/30 bg-amber-900/10 px-1.5 py-0.5 text-sm font-semibold text-foreground align-baseline"
+      >
+        <Icon className="mr-1 size-3.5 shrink-0" aria-hidden="true" />
+        {displayName.replace(/^#/, "")}
+      </span>,
+    );
+    cursor = item.start + reference.insertedText.length;
+  }
+
+  if (cursor < text.length) {
+    nodes.push(
+      <React.Fragment key={`text-${cursor}`}>{text.slice(cursor)}</React.Fragment>,
+    );
+  }
+  return nodes;
 }
 
 function formatTriggerSource(triggerContext?: AgentTriggerContext): string {

--- a/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
@@ -571,13 +571,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           setHistoryIndex(-1);
         }
       },
-      [
-        attachments,
-        historyIndex,
-        sessionFiles,
-        sessionId,
-        sessionInputFiles,
-      ],
+      [attachments, historyIndex, sessionFiles, sessionId, sessionInputFiles],
     );
 
     const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useImperativeHandle,
   forwardRef,
+  useMemo,
 } from "react";
 import {
   ArrowUp,
@@ -14,9 +15,10 @@ import {
   Mic,
   MicOff,
   Upload,
+  FileText,
 } from "lucide-react";
 import { uploadAttachment } from "@/features/attachments/api/attachment-api";
-import type { InputFile } from "@/features/chat/types";
+import type { ChatInputFileReference, InputFile } from "@/features/chat/types";
 import { toast } from "sonner";
 import { FileCard } from "@/components/shared/file-card";
 import {
@@ -31,9 +33,19 @@ import { useFileDropUpload } from "@/features/task-composer";
 import { cn } from "@/lib/utils";
 import { useLanguage } from "@/hooks/use-language";
 import { appendTranscribedText, useVoiceInput } from "@/features/voice";
+import {
+  filterInputFileReferences,
+  getInputFileReferenceCandidates,
+  getInputFileReferenceTrigger,
+  insertInputFileReference,
+} from "@/features/chat/lib/input-file-reference";
 
 interface ChatInputProps {
-  onSend: (content: string, attachments?: InputFile[]) => void;
+  onSend: (
+    content: string,
+    attachments?: InputFile[],
+    inputFileReferences?: ChatInputFileReference[],
+  ) => void;
   onCancel?: () => void;
   canCancel?: boolean;
   isCancelling?: boolean;
@@ -45,6 +57,7 @@ interface ChatInputProps {
 export interface ChatInputDraft {
   value: string;
   attachments?: InputFile[];
+  inputFileReferences?: ChatInputFileReference[];
 }
 
 export interface ChatInputRef {
@@ -73,28 +86,38 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const { t } = useT("translation");
     const [value, setValue] = useState("");
     const [attachments, setAttachments] = useState<InputFile[]>([]);
+    const [inputFileReferences, setInputFileReferences] = useState<
+      ChatInputFileReference[]
+    >([]);
     const [isUploading, setIsUploading] = useState(false);
     const [historyIndex, setHistoryIndex] = useState(-1);
+    const [selectionStart, setSelectionStart] = useState(0);
+    const [fileReferenceActiveIndex, setFileReferenceActiveIndex] = useState(0);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const valueRef = useRef(value);
     const uploadAbortControllerRef = useRef<AbortController | null>(null);
     const lng = useLanguage();
 
-    const syncTextareaValue = useCallback((nextValue: string) => {
-      const textarea = textareaRef.current;
-      if (!textarea) return;
-      textarea.focus();
-      textarea.setSelectionRange(nextValue.length, nextValue.length);
-      textarea.style.height = "auto";
-      textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
-    }, []);
+    const syncTextareaValue = useCallback(
+      (nextValue: string, cursor?: number) => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+        const nextCursor = cursor ?? nextValue.length;
+        textarea.focus();
+        textarea.setSelectionRange(nextCursor, nextCursor);
+        textarea.style.height = "auto";
+        textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+      },
+      [],
+    );
 
     const applyValue = useCallback(
-      (nextValue: string) => {
+      (nextValue: string, cursor?: number) => {
         setValue(nextValue);
+        setSelectionStart(cursor ?? nextValue.length);
         requestAnimationFrame(() => {
-          syncTextareaValue(nextValue);
+          syncTextareaValue(nextValue, cursor);
         });
       },
       [syncTextareaValue],
@@ -123,6 +146,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     useImperativeHandle(ref, () => ({
       setValueAndFocus: (newValue: string) => {
         setHistoryIndex(-1);
+        setInputFileReferences([]);
         applyValue(newValue);
       },
       appendValueAndFocus: (newValue: string) => {
@@ -132,9 +156,18 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       setDraftAndFocus: ({
         value: newValue,
         attachments: nextAttachments,
+        inputFileReferences: nextInputFileReferences,
       }: ChatInputDraft) => {
         setHistoryIndex(-1);
-        setAttachments(nextAttachments ?? []);
+        const draftAttachments = nextAttachments ?? [];
+        setAttachments(draftAttachments);
+        setInputFileReferences(
+          filterInputFileReferences(
+            nextInputFileReferences,
+            newValue,
+            draftAttachments,
+          ),
+        );
         applyValue(newValue);
       },
     }));
@@ -147,6 +180,63 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onChange: setValue,
       textareaRef,
     });
+
+    const inputFileReferenceTrigger = useMemo(
+      () => getInputFileReferenceTrigger(value, selectionStart),
+      [selectionStart, value],
+    );
+    const inputFileReferenceCandidates = useMemo(
+      () =>
+        inputFileReferenceTrigger
+          ? getInputFileReferenceCandidates(
+              attachments,
+              inputFileReferenceTrigger.query,
+            )
+          : [],
+      [attachments, inputFileReferenceTrigger],
+    );
+    const isInputFileReferenceOpen =
+      !slashAutocomplete.isOpen &&
+      Boolean(inputFileReferenceTrigger) &&
+      inputFileReferenceCandidates.length > 0;
+
+    useEffect(() => {
+      setFileReferenceActiveIndex(0);
+    }, [inputFileReferenceTrigger?.query, inputFileReferenceCandidates.length]);
+
+    const applyInputFileReferenceSelection = useCallback(
+      (index: number) => {
+        const candidate = inputFileReferenceCandidates[index];
+        const textarea = textareaRef.current;
+        if (!candidate || !textarea) return;
+
+        const result = insertInputFileReference(
+          value,
+          textarea.selectionStart,
+          textarea.selectionEnd,
+          candidate,
+        );
+        if (!result) return;
+
+        setHistoryIndex(-1);
+        setValue(result.value);
+        setSelectionStart(result.cursor);
+        setInputFileReferences((prev) => [
+          ...filterInputFileReferences(prev, result.value, attachments),
+          result.reference,
+        ]);
+        requestAnimationFrame(() => {
+          syncTextareaValue(result.value, result.cursor);
+        });
+      },
+      [
+        attachments,
+        inputFileReferenceCandidates,
+        syncTextareaValue,
+        value,
+      ],
+    );
+
     const uploadFiles = useCallback(
       async (files: File[]) => {
         if (files.length === 0) return;
@@ -293,15 +383,21 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
       const content = value;
       const currentAttachments = [...attachments];
+      const currentReferences = filterInputFileReferences(
+        inputFileReferences,
+        content,
+        currentAttachments,
+      );
       setHistoryIndex(-1);
       setValue(""); // Clear immediately
       setAttachments([]);
+      setInputFileReferences([]);
       // Reset textarea height
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
-      onSend(content, currentAttachments);
-    }, [attachments, onSend, value, voiceInput.isBusy]);
+      onSend(content, currentAttachments, currentReferences);
+    }, [attachments, inputFileReferences, onSend, value, voiceInput.isBusy]);
 
     // Reset textarea height when value becomes empty
     useEffect(() => {
@@ -318,6 +414,30 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (isInputFileReferenceOpen) {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setFileReferenceActiveIndex((current) =>
+              Math.min(current + 1, inputFileReferenceCandidates.length - 1),
+            );
+            return;
+          }
+          if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setFileReferenceActiveIndex((current) => Math.max(current - 1, 0));
+            return;
+          }
+          if (e.key === "Enter" || e.key === "Tab") {
+            e.preventDefault();
+            applyInputFileReferenceSelection(fileReferenceActiveIndex);
+            return;
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            setSelectionStart(-1);
+            return;
+          }
+        }
         if (slashAutocomplete.handleKeyDown(e)) return;
         if (
           disabled ||
@@ -340,6 +460,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                 : Math.max(0, historyIndex - 1);
             setHistoryIndex(nextIndex);
             applyValue(history[nextIndex] ?? "");
+            setInputFileReferences([]);
             return;
           }
           if (e.key === "ArrowDown") {
@@ -349,6 +470,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
               historyIndex >= history.length - 1 ? -1 : historyIndex + 1;
             setHistoryIndex(nextIndex);
             applyValue(nextIndex === -1 ? "" : (history[nextIndex] ?? ""));
+            setInputFileReferences([]);
             return;
           }
         }
@@ -373,6 +495,10 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         value,
         attachments,
         handleSend,
+        isInputFileReferenceOpen,
+        inputFileReferenceCandidates.length,
+        applyInputFileReferenceSelection,
+        fileReferenceActiveIndex,
         slashAutocomplete,
         disabled,
         historyIndex,
@@ -393,12 +519,17 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
     const handleInputChange = useCallback(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        setValue(e.target.value);
+        const nextValue = e.target.value;
+        setValue(nextValue);
+        setSelectionStart(e.target.selectionStart);
+        setInputFileReferences((prev) =>
+          filterInputFileReferences(prev, nextValue, attachments),
+        );
         if (historyIndex !== -1) {
           setHistoryIndex(-1);
         }
       },
-      [historyIndex],
+      [attachments, historyIndex],
     );
 
     const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -414,7 +545,13 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     };
 
     const removeAttachment = (index: number) => {
-      setAttachments((prev) => prev.filter((_, i) => i !== index));
+      setAttachments((prev) => {
+        const next = prev.filter((_, i) => i !== index);
+        setInputFileReferences((current) =>
+          filterInputFileReferences(current, value, next),
+        );
+        return next;
+      });
     };
 
     const hasDraft = value.trim().length > 0 || attachments.length > 0;
@@ -474,6 +611,44 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                 </div>
               </div>
             ) : null}
+            {isInputFileReferenceOpen ? (
+              <div className="absolute bottom-full left-0 z-50 mb-2 w-full overflow-hidden rounded-lg border border-border bg-popover shadow-md">
+                <div className="max-h-64 overflow-auto py-1">
+                  {inputFileReferenceCandidates.map((item, idx) => {
+                    const selected = idx === fileReferenceActiveIndex;
+                    return (
+                      <button
+                        key={item.source}
+                        type="button"
+                        onMouseEnter={() => setFileReferenceActiveIndex(idx)}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          applyInputFileReferenceSelection(idx);
+                        }}
+                        className={cn(
+                          "flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left text-sm",
+                          selected
+                            ? "bg-accent text-accent-foreground"
+                            : "hover:bg-accent/50",
+                        )}
+                      >
+                        <FileText className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium">
+                            #{item.displayName}
+                          </span>
+                          {item.description ? (
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {item.description}
+                            </span>
+                          ) : null}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
 
             <Tooltip>
               <TooltipTrigger asChild>
@@ -500,6 +675,8 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
               ref={textareaRef}
               value={value}
               onChange={handleInputChange}
+              onClick={(e) => setSelectionStart(e.currentTarget.selectionStart)}
+              onKeyUp={(e) => setSelectionStart(e.currentTarget.selectionStart)}
               onKeyDown={handleKeyDown}
               onCompositionStart={handleCompositionStart}
               onCompositionEnd={handleCompositionEnd}

--- a/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-input.tsx
@@ -18,7 +18,8 @@ import {
   FileText,
 } from "lucide-react";
 import { uploadAttachment } from "@/features/attachments/api/attachment-api";
-import type { ChatInputFileReference, InputFile } from "@/features/chat/types";
+import type { ChatFileReference, InputFile } from "@/features/chat/types";
+import type { FileNode } from "@/features/chat/types/api/file";
 import { toast } from "sonner";
 import { FileCard } from "@/components/shared/file-card";
 import {
@@ -44,20 +45,24 @@ interface ChatInputProps {
   onSend: (
     content: string,
     attachments?: InputFile[],
-    inputFileReferences?: ChatInputFileReference[],
+    fileReferences?: ChatFileReference[],
   ) => void;
   onCancel?: () => void;
   canCancel?: boolean;
   isCancelling?: boolean;
   disabled?: boolean;
   history?: string[];
+  sessionId?: string | null;
+  sessionInputFiles?: InputFile[];
+  sessionFiles?: FileNode[];
   className?: string;
 }
 
 export interface ChatInputDraft {
   value: string;
   attachments?: InputFile[];
-  inputFileReferences?: ChatInputFileReference[];
+  fileReferences?: ChatFileReference[];
+  inputFileReferences?: ChatFileReference[];
 }
 
 export interface ChatInputRef {
@@ -79,6 +84,9 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       isCancelling = false,
       disabled = false,
       history = [],
+      sessionId,
+      sessionInputFiles = [],
+      sessionFiles = [],
       className,
     },
     ref,
@@ -87,7 +95,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const [value, setValue] = useState("");
     const [attachments, setAttachments] = useState<InputFile[]>([]);
     const [inputFileReferences, setInputFileReferences] = useState<
-      ChatInputFileReference[]
+      ChatFileReference[]
     >([]);
     const [isUploading, setIsUploading] = useState(false);
     const [historyIndex, setHistoryIndex] = useState(-1);
@@ -156,16 +164,20 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       setDraftAndFocus: ({
         value: newValue,
         attachments: nextAttachments,
+        fileReferences: nextFileReferences,
         inputFileReferences: nextInputFileReferences,
       }: ChatInputDraft) => {
         setHistoryIndex(-1);
         const draftAttachments = nextAttachments ?? [];
         setAttachments(draftAttachments);
+        const draftFileReferences =
+          nextFileReferences ?? nextInputFileReferences;
         setInputFileReferences(
           filterInputFileReferences(
-            nextInputFileReferences,
+            draftFileReferences,
             newValue,
-            draftAttachments,
+            [...draftAttachments, ...sessionInputFiles],
+            { sessionId, workspaceFiles: sessionFiles },
           ),
         );
         applyValue(newValue);
@@ -189,11 +201,18 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       () =>
         inputFileReferenceTrigger
           ? getInputFileReferenceCandidates(
-              attachments,
+              [...attachments, ...sessionInputFiles],
               inputFileReferenceTrigger.query,
+              { sessionId, workspaceFiles: sessionFiles },
             )
           : [],
-      [attachments, inputFileReferenceTrigger],
+      [
+        attachments,
+        inputFileReferenceTrigger,
+        sessionFiles,
+        sessionId,
+        sessionInputFiles,
+      ],
     );
     const isInputFileReferenceOpen =
       !slashAutocomplete.isOpen &&
@@ -222,7 +241,12 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         setValue(result.value);
         setSelectionStart(result.cursor);
         setInputFileReferences((prev) => [
-          ...filterInputFileReferences(prev, result.value, attachments),
+          ...filterInputFileReferences(
+            prev,
+            result.value,
+            [...attachments, ...sessionInputFiles],
+            { sessionId, workspaceFiles: sessionFiles },
+          ),
           result.reference,
         ]);
         requestAnimationFrame(() => {
@@ -232,6 +256,9 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       [
         attachments,
         inputFileReferenceCandidates,
+        sessionFiles,
+        sessionId,
+        sessionInputFiles,
         syncTextareaValue,
         value,
       ],
@@ -386,7 +413,8 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       const currentReferences = filterInputFileReferences(
         inputFileReferences,
         content,
-        currentAttachments,
+        [...currentAttachments, ...sessionInputFiles],
+        { sessionId, workspaceFiles: sessionFiles },
       );
       setHistoryIndex(-1);
       setValue(""); // Clear immediately
@@ -397,7 +425,16 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         textareaRef.current.style.height = "auto";
       }
       onSend(content, currentAttachments, currentReferences);
-    }, [attachments, inputFileReferences, onSend, value, voiceInput.isBusy]);
+    }, [
+      attachments,
+      inputFileReferences,
+      onSend,
+      sessionFiles,
+      sessionId,
+      sessionInputFiles,
+      value,
+      voiceInput.isBusy,
+    ]);
 
     // Reset textarea height when value becomes empty
     useEffect(() => {
@@ -523,13 +560,24 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         setValue(nextValue);
         setSelectionStart(e.target.selectionStart);
         setInputFileReferences((prev) =>
-          filterInputFileReferences(prev, nextValue, attachments),
+          filterInputFileReferences(
+            prev,
+            nextValue,
+            [...attachments, ...sessionInputFiles],
+            { sessionId, workspaceFiles: sessionFiles },
+          ),
         );
         if (historyIndex !== -1) {
           setHistoryIndex(-1);
         }
       },
-      [attachments, historyIndex],
+      [
+        attachments,
+        historyIndex,
+        sessionFiles,
+        sessionId,
+        sessionInputFiles,
+      ],
     );
 
     const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -548,7 +596,12 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       setAttachments((prev) => {
         const next = prev.filter((_, i) => i !== index);
         setInputFileReferences((current) =>
-          filterInputFileReferences(current, value, next),
+          filterInputFileReferences(
+            current,
+            value,
+            [...next, ...sessionInputFiles],
+            { sessionId, workspaceFiles: sessionFiles },
+          ),
         );
         return next;
       });
@@ -618,7 +671,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                     const selected = idx === fileReferenceActiveIndex;
                     return (
                       <button
-                        key={item.source}
+                        key={item.id}
                         type="button"
                         onMouseEnter={() => setFileReferenceActiveIndex(idx)}
                         onMouseDown={(e) => {

--- a/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
@@ -39,8 +39,9 @@ import {
   regenerateMessageAction,
 } from "@/features/chat/actions/session-actions";
 import type {
-  ChatInputFileReference,
+  ChatFileReference,
   ExecutionSession,
+  FileNode,
   InputFile,
   StatePatch,
   UserInputRequest,
@@ -247,6 +248,51 @@ export function ChatPanel({
     modifyPendingMessage,
     deletePendingMessage,
   } = usePendingMessages({ session });
+  const [sessionFiles, setSessionFiles] = React.useState<FileNode[]>([]);
+
+  const sessionInputFiles = React.useMemo(() => {
+    const bySource = new Map<string, InputFile>();
+    for (const message of displayMessages) {
+      for (const attachment of message.attachments ?? []) {
+        const source = (attachment.source || "").trim();
+        if (source && !bySource.has(source)) {
+          bySource.set(source, attachment);
+        }
+      }
+    }
+    for (const message of pendingMessages) {
+      for (const attachment of message.attachments ?? []) {
+        const source = (attachment.source || "").trim();
+        if (source && !bySource.has(source)) {
+          bySource.set(source, attachment);
+        }
+      }
+    }
+    return Array.from(bySource.values());
+  }, [displayMessages, pendingMessages]);
+
+  React.useEffect(() => {
+    const sessionId = session?.session_id;
+    if (!sessionId) {
+      setSessionFiles([]);
+      return;
+    }
+
+    let cancelled = false;
+    void chatService.getFiles(sessionId).then((files) => {
+      if (!cancelled) {
+        setSessionFiles(files);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    session?.session_id,
+    session?.state_patch?.workspace_state?.file_change_count,
+    session?.workspace_export_status,
+  ]);
 
   // Determine if session is running/active
   const isSessionActive =
@@ -689,7 +735,7 @@ export function ChatPanel({
     async (
       content: string,
       attachments?: InputFile[],
-      inputFileReferences?: ChatInputFileReference[],
+      fileReferences?: ChatFileReference[],
     ) => {
       if (!session?.session_id) return;
 
@@ -723,7 +769,7 @@ export function ChatPanel({
       const result = await sendMessage(
         content,
         attachments,
-        inputFileReferences,
+        fileReferences,
         selectedModelSelection,
       );
 
@@ -739,7 +785,7 @@ export function ChatPanel({
           id: result.queueItemId ?? `queued-${Date.now()}`,
           content,
           attachments,
-          inputFileReferences,
+          inputFileReferences: fileReferences,
           status: "queued",
         });
       }
@@ -1495,6 +1541,9 @@ export function ChatPanel({
           session?.status === "canceling"
         }
         history={userPromptHistory}
+        sessionId={session?.session_id}
+        sessionInputFiles={sessionInputFiles}
+        sessionFiles={sessionFiles}
         className={
           isRightPanelCollapsed ? collapsedContentInsetClass : undefined
         }

--- a/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
@@ -39,6 +39,7 @@ import {
   regenerateMessageAction,
 } from "@/features/chat/actions/session-actions";
 import type {
+  ChatInputFileReference,
   ExecutionSession,
   InputFile,
   StatePatch,
@@ -685,7 +686,11 @@ export function ChatPanel({
 
   // Handle send from input
   const handleSend = React.useCallback(
-    async (content: string, attachments?: InputFile[]) => {
+    async (
+      content: string,
+      attachments?: InputFile[],
+      inputFileReferences?: ChatInputFileReference[],
+    ) => {
       if (!session?.session_id) return;
 
       if (hasActiveUserInput) {
@@ -718,6 +723,7 @@ export function ChatPanel({
       const result = await sendMessage(
         content,
         attachments,
+        inputFileReferences,
         selectedModelSelection,
       );
 
@@ -733,6 +739,7 @@ export function ChatPanel({
           id: result.queueItemId ?? `queued-${Date.now()}`,
           content,
           attachments,
+          inputFileReferences,
           status: "queued",
         });
       }
@@ -842,6 +849,7 @@ export function ChatPanel({
         inputRef.current?.setDraftAndFocus({
           value: draft.content,
           attachments: draft.attachments,
+          inputFileReferences: draft.inputFileReferences,
         });
         await refreshTasks();
       } catch (error) {

--- a/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
+++ b/frontend/features/chat/components/execution/chat-panel/chat-panel.tsx
@@ -785,7 +785,7 @@ export function ChatPanel({
           id: result.queueItemId ?? `queued-${Date.now()}`,
           content,
           attachments,
-          inputFileReferences: fileReferences,
+          fileReferences,
           status: "queued",
         });
       }
@@ -895,7 +895,7 @@ export function ChatPanel({
         inputRef.current?.setDraftAndFocus({
           value: draft.content,
           attachments: draft.attachments,
-          inputFileReferences: draft.inputFileReferences,
+          fileReferences: draft.fileReferences ?? draft.inputFileReferences,
         });
         await refreshTasks();
       } catch (error) {

--- a/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
+++ b/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
@@ -10,6 +10,7 @@ import {
   getRunsBySessionAction,
 } from "@/features/chat/actions/query-actions";
 import type {
+  ChatInputFileReference,
   ChatMessage,
   ExecutionSession,
   InputFile,
@@ -34,8 +35,8 @@ interface UseChatMessagesReturn {
   showTypingIndicator: boolean;
   sendMessage: (
     content: string,
-
     attachments?: InputFile[],
+    inputFileReferences?: ChatInputFileReference[],
     modelSelection?: ModelSelection | null,
   ) => Promise<TaskEnqueueActionResult | null>;
   beginOptimisticRegenerate: (assistantMessageId: number) => string;
@@ -502,6 +503,7 @@ export function useChatMessages({
     async (
       content: string,
       attachments?: InputFile[],
+      inputFileReferences?: ChatInputFileReference[],
       modelSelection?: ModelSelection | null,
     ): Promise<TaskEnqueueActionResult | null> => {
       if (!session?.session_id) return null;
@@ -522,6 +524,9 @@ export function useChatMessages({
           content: normalizedContent,
           status: "sent",
           timestamp: new Date().toISOString(),
+          metadata: {
+            inputFileReferences,
+          },
           attachments,
         };
 
@@ -535,6 +540,7 @@ export function useChatMessages({
           sessionId,
           content: normalizedContent,
           attachments,
+          input_file_references: inputFileReferences,
           model: modelSelection?.modelId,
           model_provider_id: modelSelection?.providerId,
         });

--- a/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
+++ b/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
@@ -10,7 +10,7 @@ import {
   getRunsBySessionAction,
 } from "@/features/chat/actions/query-actions";
 import type {
-  ChatInputFileReference,
+  ChatFileReference,
   ChatMessage,
   ExecutionSession,
   InputFile,
@@ -36,7 +36,7 @@ interface UseChatMessagesReturn {
   sendMessage: (
     content: string,
     attachments?: InputFile[],
-    inputFileReferences?: ChatInputFileReference[],
+    fileReferences?: ChatFileReference[],
     modelSelection?: ModelSelection | null,
   ) => Promise<TaskEnqueueActionResult | null>;
   beginOptimisticRegenerate: (assistantMessageId: number) => string;
@@ -503,7 +503,7 @@ export function useChatMessages({
     async (
       content: string,
       attachments?: InputFile[],
-      inputFileReferences?: ChatInputFileReference[],
+      fileReferences?: ChatFileReference[],
       modelSelection?: ModelSelection | null,
     ): Promise<TaskEnqueueActionResult | null> => {
       if (!session?.session_id) return null;
@@ -525,7 +525,7 @@ export function useChatMessages({
           status: "sent",
           timestamp: new Date().toISOString(),
           metadata: {
-            inputFileReferences,
+            inputFileReferences: fileReferences,
           },
           attachments,
         };
@@ -540,7 +540,7 @@ export function useChatMessages({
           sessionId,
           content: normalizedContent,
           attachments,
-          input_file_references: inputFileReferences,
+          file_references: fileReferences,
           model: modelSelection?.modelId,
           model_provider_id: modelSelection?.providerId,
         });

--- a/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
+++ b/frontend/features/chat/components/execution/chat-panel/hooks/use-chat-messages.ts
@@ -525,7 +525,7 @@ export function useChatMessages({
           status: "sent",
           timestamp: new Date().toISOString(),
           metadata: {
-            inputFileReferences: fileReferences,
+            fileReferences,
           },
           attachments,
         };

--- a/frontend/features/chat/components/execution/chat-panel/hooks/use-pending-messages.ts
+++ b/frontend/features/chat/components/execution/chat-panel/hooks/use-pending-messages.ts
@@ -5,7 +5,11 @@ import {
   type TaskEnqueueActionResult,
 } from "@/features/chat/actions/session-actions";
 import { getQueuedQueriesAction } from "@/features/chat/actions/query-actions";
-import type { ExecutionSession, InputFile } from "@/features/chat/types";
+import type {
+  ChatFileReference,
+  ExecutionSession,
+  InputFile,
+} from "@/features/chat/types";
 import type { ModelSelection } from "@/features/chat/lib/model-catalog";
 
 const PENDING_MESSAGE_POLLING_INTERVAL = 3000;
@@ -18,6 +22,8 @@ export interface PendingMessage {
   id: string;
   content: string;
   attachments?: InputFile[];
+  fileReferences?: ChatFileReference[];
+  inputFileReferences?: ChatFileReference[];
   modelSelection?: ModelSelection | null;
   status: "queued" | "paused";
   sequenceNo: number;
@@ -41,6 +47,8 @@ function toPendingMessage(item: {
   queue_item_id: string;
   prompt: string;
   attachments?: InputFile[];
+  file_references?: ChatFileReference[] | null;
+  input_file_references?: ChatFileReference[] | null;
   status: "queued" | "paused" | "promoted" | "canceled";
   sequence_no: number;
 }): PendingMessage {
@@ -48,6 +56,10 @@ function toPendingMessage(item: {
     id: item.queue_item_id,
     content: item.prompt,
     attachments: item.attachments ?? undefined,
+    fileReferences:
+      item.file_references ?? item.input_file_references ?? undefined,
+    inputFileReferences:
+      item.file_references ?? item.input_file_references ?? undefined,
     status: item.status === "paused" ? "paused" : "queued",
     sequenceNo: item.sequence_no,
   };

--- a/frontend/features/chat/lib/input-file-reference.test.ts
+++ b/frontend/features/chat/lib/input-file-reference.test.ts
@@ -101,7 +101,12 @@ test("insertInputFileReference replaces trigger with readable token", () => {
   const candidate = getInputFileReferenceCandidates(files, "des")[0];
   assert.ok(candidate);
 
-  const result = insertInputFileReference("please read #des", 16, 16, candidate);
+  const result = insertInputFileReference(
+    "please read #des",
+    16,
+    16,
+    candidate,
+  );
   assert.ok(result);
   assert.equal(result.value, "please read #design.pdf ");
   assert.equal(result.cursor, 24);
@@ -133,11 +138,8 @@ test("filterInputFileReferences removes deleted tokens and missing files", () =>
   assert.ok(inserted);
 
   assert.equal(
-    filterInputFileReferences(
-      [inserted.reference],
-      "read #design.pdf",
-      files,
-    ).length,
+    filterInputFileReferences([inserted.reference], "read #design.pdf", files)
+      .length,
     1,
   );
   assert.equal(

--- a/frontend/features/chat/lib/input-file-reference.test.ts
+++ b/frontend/features/chat/lib/input-file-reference.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  filterInputFileReferences,
+  getInputFileReferenceCandidates,
+  getInputFileReferenceTrigger,
+  insertInputFileReference,
+} from "./input-file-reference.ts";
+import type { InputFile } from "@/features/chat/types/api/session";
+
+const files: InputFile[] = [
+  {
+    id: "file-1",
+    name: "design.pdf",
+    source: "s3://bucket/design.pdf",
+    size: 120,
+    content_type: "application/pdf",
+  },
+  {
+    id: "file-2",
+    name: "notes.md",
+    source: "s3://bucket/notes.md",
+    size: 80,
+    content_type: "text/markdown",
+  },
+  {
+    id: "file-duplicate",
+    name: "design.pdf",
+    source: "s3://bucket/design.pdf",
+    size: 120,
+    content_type: "application/pdf",
+  },
+];
+
+test("getInputFileReferenceTrigger detects current hash token only", () => {
+  assert.deepEqual(getInputFileReferenceTrigger("check #des", 10), {
+    start: 6,
+    end: 10,
+    query: "des",
+  });
+  assert.equal(getInputFileReferenceTrigger("check /run", 10), null);
+  assert.equal(getInputFileReferenceTrigger("check #bad token", 16), null);
+});
+
+test("getInputFileReferenceCandidates filters by display name and dedupes source", () => {
+  const candidates = getInputFileReferenceCandidates(files, "des");
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.displayName, "design.pdf");
+  assert.equal(candidates[0]?.source, "s3://bucket/design.pdf");
+});
+
+test("insertInputFileReference replaces trigger with readable token", () => {
+  const candidate = getInputFileReferenceCandidates(files, "des")[0];
+  assert.ok(candidate);
+
+  const result = insertInputFileReference("please read #des", 16, 16, candidate);
+  assert.ok(result);
+  assert.equal(result.value, "please read #design.pdf ");
+  assert.equal(result.cursor, 24);
+  assert.equal(result.reference.insertedText, "#design.pdf");
+  assert.deepEqual(result.reference.range, { start: 12, end: 23 });
+});
+
+test("filterInputFileReferences removes deleted tokens and missing files", () => {
+  const candidate = getInputFileReferenceCandidates(files, "des")[0];
+  assert.ok(candidate);
+  const inserted = insertInputFileReference("read #des", 9, 9, candidate);
+  assert.ok(inserted);
+
+  assert.equal(
+    filterInputFileReferences(
+      [inserted.reference],
+      "read #design.pdf",
+      files,
+    ).length,
+    1,
+  );
+  assert.equal(
+    filterInputFileReferences([inserted.reference], "read design.pdf", files)
+      .length,
+    0,
+  );
+  assert.equal(
+    filterInputFileReferences([inserted.reference], inserted.value, [
+      files[1] as InputFile,
+    ]).length,
+    0,
+  );
+});

--- a/frontend/features/chat/lib/input-file-reference.test.ts
+++ b/frontend/features/chat/lib/input-file-reference.test.ts
@@ -8,6 +8,7 @@ import {
   insertInputFileReference,
 } from "./input-file-reference.ts";
 import type { InputFile } from "@/features/chat/types/api/session";
+import type { FileNode } from "@/features/chat/types/api/file";
 
 const files: InputFile[] = [
   {
@@ -33,6 +34,33 @@ const files: InputFile[] = [
   },
 ];
 
+const workspaceFiles: FileNode[] = [
+  {
+    id: "/reports/summary.md",
+    name: "summary.md",
+    path: "/reports/summary.md",
+    type: "file",
+    mimeType: "text/markdown",
+    source_kind: "workspace_export",
+    oss_meta: { size: 42 },
+  },
+  {
+    id: "/nested",
+    name: "nested",
+    path: "/nested",
+    type: "folder",
+    children: [
+      {
+        id: "/nested/result.json",
+        name: "result.json",
+        path: "/nested/result.json",
+        type: "file",
+        mimeType: "application/json",
+      },
+    ],
+  },
+];
+
 test("getInputFileReferenceTrigger detects current hash token only", () => {
   assert.deepEqual(getInputFileReferenceTrigger("check #des", 10), {
     start: 6,
@@ -47,7 +75,26 @@ test("getInputFileReferenceCandidates filters by display name and dedupes source
   const candidates = getInputFileReferenceCandidates(files, "des");
   assert.equal(candidates.length, 1);
   assert.equal(candidates[0]?.displayName, "design.pdf");
-  assert.equal(candidates[0]?.source, "s3://bucket/design.pdf");
+  assert.equal(candidates[0]?.kind, "input_file");
+  assert.equal(
+    candidates[0]?.kind === "input_file" ? candidates[0].source : null,
+    "s3://bucket/design.pdf",
+  );
+});
+
+test("getInputFileReferenceCandidates includes workspace files from the session", () => {
+  const candidates = getInputFileReferenceCandidates(files, "summary", {
+    sessionId: "session-1",
+    workspaceFiles,
+  });
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.kind, "workspace_file");
+  assert.equal(candidates[0]?.displayName, "summary.md");
+  assert.equal(
+    candidates[0]?.kind === "workspace_file" ? candidates[0].path : null,
+    "/reports/summary.md",
+  );
 });
 
 test("insertInputFileReference replaces trigger with readable token", () => {
@@ -60,6 +107,23 @@ test("insertInputFileReference replaces trigger with readable token", () => {
   assert.equal(result.cursor, 24);
   assert.equal(result.reference.insertedText, "#design.pdf");
   assert.deepEqual(result.reference.range, { start: 12, end: 23 });
+});
+
+test("insertInputFileReference creates workspace file references", () => {
+  const candidate = getInputFileReferenceCandidates(files, "result", {
+    sessionId: "session-1",
+    workspaceFiles,
+  })[0];
+  assert.ok(candidate);
+
+  const result = insertInputFileReference("open #res", 9, 9, candidate);
+  assert.ok(result);
+  assert.equal(result.value, "open #result.json ");
+  assert.equal(result.reference.kind, "workspace_file");
+  assert.equal(
+    result.reference.kind === "workspace_file" ? result.reference.path : null,
+    "/nested/result.json",
+  );
 });
 
 test("filterInputFileReferences removes deleted tokens and missing files", () => {
@@ -85,6 +149,31 @@ test("filterInputFileReferences removes deleted tokens and missing files", () =>
     filterInputFileReferences([inserted.reference], inserted.value, [
       files[1] as InputFile,
     ]).length,
+    0,
+  );
+});
+
+test("filterInputFileReferences keeps workspace references by session path", () => {
+  const candidate = getInputFileReferenceCandidates(files, "summary", {
+    sessionId: "session-1",
+    workspaceFiles,
+  })[0];
+  assert.ok(candidate);
+  const inserted = insertInputFileReference("read #sum", 9, 9, candidate);
+  assert.ok(inserted);
+
+  assert.equal(
+    filterInputFileReferences([inserted.reference], inserted.value, files, {
+      sessionId: "session-1",
+      workspaceFiles,
+    }).length,
+    1,
+  );
+  assert.equal(
+    filterInputFileReferences([inserted.reference], inserted.value, files, {
+      sessionId: "session-2",
+      workspaceFiles,
+    }).length,
     0,
   );
 });

--- a/frontend/features/chat/lib/input-file-reference.ts
+++ b/frontend/features/chat/lib/input-file-reference.ts
@@ -1,0 +1,164 @@
+import type {
+  ChatInputFileReference,
+  InputFile,
+} from "@/features/chat/types/api/session";
+
+export interface InputFileReferenceTrigger {
+  start: number;
+  end: number;
+  query: string;
+}
+
+export interface InputFileReferenceCandidate {
+  file: InputFile;
+  source: string;
+  displayName: string;
+  description: string | null;
+}
+
+export interface InsertInputFileReferenceResult {
+  value: string;
+  cursor: number;
+  reference: ChatInputFileReference;
+}
+
+function normalizeSource(source: unknown): string {
+  return typeof source === "string" ? source.trim() : "";
+}
+
+function normalizeDisplayName(file: InputFile): string {
+  const name = (file.name || "").trim();
+  if (name) return name;
+  const source = normalizeSource(file.source);
+  return source || "file";
+}
+
+function formatDescription(file: InputFile): string | null {
+  const parts = [
+    typeof file.content_type === "string" && file.content_type.trim()
+      ? file.content_type.trim()
+      : null,
+    typeof file.size === "number" ? `${file.size} B` : null,
+    typeof file.path === "string" && file.path.trim() ? file.path.trim() : null,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function getInputFileReferenceTrigger(
+  value: string,
+  cursor: number,
+): InputFileReferenceTrigger | null {
+  const boundedCursor = Math.max(0, Math.min(cursor, value.length));
+  const beforeCursor = value.slice(0, boundedCursor);
+  const tokenStart = beforeCursor.search(/(?:^|\s)#([^\s#/]*)$/);
+  if (tokenStart === -1) return null;
+
+  const hashIndex = beforeCursor.indexOf("#", tokenStart);
+  if (hashIndex === -1) return null;
+
+  return {
+    start: hashIndex,
+    end: boundedCursor,
+    query: beforeCursor.slice(hashIndex + 1),
+  };
+}
+
+export function getInputFileReferenceCandidates(
+  files: InputFile[],
+  query: string,
+): InputFileReferenceCandidate[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const seenSources = new Set<string>();
+  const candidates: InputFileReferenceCandidate[] = [];
+
+  for (const file of files) {
+    const source = normalizeSource(file.source);
+    if (!source || seenSources.has(source)) continue;
+
+    const displayName = normalizeDisplayName(file);
+    if (
+      normalizedQuery &&
+      !displayName.toLowerCase().includes(normalizedQuery)
+    ) {
+      continue;
+    }
+
+    candidates.push({
+      file,
+      source,
+      displayName,
+      description: formatDescription(file),
+    });
+    seenSources.add(source);
+  }
+
+  return candidates;
+}
+
+export function insertInputFileReference(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  candidate: InputFileReferenceCandidate,
+): InsertInputFileReferenceResult | null {
+  const trigger = getInputFileReferenceTrigger(value, selectionStart);
+  if (!trigger) return null;
+
+  const insertedText = `#${candidate.displayName}`;
+  const replacement = `${insertedText} `;
+  const start = trigger.start;
+  const end = Math.max(trigger.end, selectionEnd);
+  const nextValue = `${value.slice(0, start)}${replacement}${value.slice(end)}`;
+  const rangeEnd = start + insertedText.length;
+
+  return {
+    value: nextValue,
+    cursor: start + replacement.length,
+    reference: {
+      id: `${candidate.source}:${start}:${rangeEnd}`,
+      kind: "input_file",
+      source: candidate.source,
+      insertedText,
+      displayName: candidate.displayName,
+      range: { start, end: rangeEnd },
+      metadata: {
+        inputFileId: candidate.file.id ?? null,
+        size: candidate.file.size ?? null,
+        contentType: candidate.file.content_type ?? null,
+        path: candidate.file.path ?? null,
+      },
+    },
+  };
+}
+
+export function filterInputFileReferences(
+  references: ChatInputFileReference[] | undefined,
+  value: string,
+  files: InputFile[],
+): ChatInputFileReference[] {
+  if (!references || references.length === 0) return [];
+
+  const availableSources = new Set(
+    files.map((file) => normalizeSource(file.source)).filter(Boolean),
+  );
+  const nextReferences: ChatInputFileReference[] = [];
+
+  for (const reference of references) {
+    const source = normalizeSource(reference.source);
+    const insertedText = reference.insertedText.trim();
+    if (!source || !availableSources.has(source) || !insertedText) continue;
+
+    const start = value.indexOf(insertedText);
+    if (start === -1) continue;
+
+    nextReferences.push({
+      ...reference,
+      range: {
+        start,
+        end: start + insertedText.length,
+      },
+    });
+  }
+
+  return nextReferences;
+}

--- a/frontend/features/chat/lib/input-file-reference.ts
+++ b/frontend/features/chat/lib/input-file-reference.ts
@@ -1,7 +1,8 @@
 import type {
-  ChatInputFileReference,
+  ChatFileReference,
   InputFile,
 } from "@/features/chat/types/api/session";
+import type { FileNode } from "@/features/chat/types/api/file";
 
 export interface InputFileReferenceTrigger {
   start: number;
@@ -9,17 +10,36 @@ export interface InputFileReferenceTrigger {
   query: string;
 }
 
-export interface InputFileReferenceCandidate {
-  file: InputFile;
-  source: string;
+interface BaseInputFileReferenceCandidate {
+  id: string;
   displayName: string;
   description: string | null;
 }
 
+export interface UploadedInputFileReferenceCandidate
+  extends BaseInputFileReferenceCandidate {
+  kind: "input_file";
+  file: InputFile;
+  displayName: string;
+  source: string;
+}
+
+export interface WorkspaceInputFileReferenceCandidate
+  extends BaseInputFileReferenceCandidate {
+  kind: "workspace_file";
+  file: FileNode;
+  sessionId: string;
+  path: string;
+}
+
+export type InputFileReferenceCandidate =
+  | UploadedInputFileReferenceCandidate
+  | WorkspaceInputFileReferenceCandidate;
+
 export interface InsertInputFileReferenceResult {
   value: string;
   cursor: number;
-  reference: ChatInputFileReference;
+  reference: ChatFileReference;
 }
 
 function normalizeSource(source: unknown): string {
@@ -44,6 +64,54 @@ function formatDescription(file: InputFile): string | null {
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
+function normalizeWorkspacePath(path: unknown): string {
+  if (typeof path !== "string") return "";
+  const normalized = path.replace(/\\/g, "/").trim();
+  if (!normalized) return "";
+  return `/${normalized.replace(/^\/+/, "")}`;
+}
+
+function flattenWorkspaceFiles(nodes: FileNode[]): FileNode[] {
+  const files: FileNode[] = [];
+
+  function visit(items: FileNode[]) {
+    for (const item of items) {
+      if (item.type === "file") {
+        files.push(item);
+        continue;
+      }
+      if (Array.isArray(item.children)) {
+        visit(item.children);
+      }
+    }
+  }
+
+  visit(nodes);
+  return files;
+}
+
+function formatWorkspaceDescription(file: FileNode): string | null {
+  const size =
+    typeof file.oss_meta?.size === "number" ? `${file.oss_meta.size} B` : null;
+  const parts = [
+    typeof file.mimeType === "string" && file.mimeType.trim()
+      ? file.mimeType.trim()
+      : null,
+    size,
+    normalizeWorkspacePath(file.path) || null,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function matchesQuery(displayName: string, path: string, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+  return (
+    displayName.toLowerCase().includes(normalizedQuery) ||
+    path.toLowerCase().includes(normalizedQuery)
+  );
+}
+
 export function getInputFileReferenceTrigger(
   value: string,
   cursor: number,
@@ -66,30 +134,58 @@ export function getInputFileReferenceTrigger(
 export function getInputFileReferenceCandidates(
   files: InputFile[],
   query: string,
+  options?: {
+    sessionId?: string | null;
+    workspaceFiles?: FileNode[];
+  },
 ): InputFileReferenceCandidate[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  const seenSources = new Set<string>();
+  const seenKeys = new Set<string>();
   const candidates: InputFileReferenceCandidate[] = [];
 
   for (const file of files) {
     const source = normalizeSource(file.source);
-    if (!source || seenSources.has(source)) continue;
+    const key = `input_file:${source}`;
+    if (!source || seenKeys.has(key)) continue;
 
     const displayName = normalizeDisplayName(file);
-    if (
-      normalizedQuery &&
-      !displayName.toLowerCase().includes(normalizedQuery)
-    ) {
+    if (!matchesQuery(displayName, source, query)) {
       continue;
     }
 
     candidates.push({
+      id: key,
+      kind: "input_file",
       file,
       source,
       displayName,
       description: formatDescription(file),
     });
-    seenSources.add(source);
+    seenKeys.add(key);
+  }
+
+  const sessionId = (options?.sessionId || "").trim();
+  if (sessionId && options?.workspaceFiles?.length) {
+    for (const file of flattenWorkspaceFiles(options.workspaceFiles)) {
+      const path = normalizeWorkspacePath(file.path);
+      const key = `workspace_file:${sessionId}:${path}`;
+      if (!path || seenKeys.has(key)) continue;
+
+      const displayName = (file.name || path.split("/").pop() || path).trim();
+      if (!matchesQuery(displayName, path, query)) {
+        continue;
+      }
+
+      candidates.push({
+        id: key,
+        kind: "workspace_file",
+        file,
+        sessionId,
+        path,
+        displayName,
+        description: formatWorkspaceDescription(file),
+      });
+      seenKeys.add(key);
+    }
   }
 
   return candidates;
@@ -110,43 +206,87 @@ export function insertInputFileReference(
   const end = Math.max(trigger.end, selectionEnd);
   const nextValue = `${value.slice(0, start)}${replacement}${value.slice(end)}`;
   const rangeEnd = start + insertedText.length;
+  const range = { start, end: rangeEnd };
+
+  const reference: ChatFileReference =
+    candidate.kind === "input_file"
+      ? {
+          id: `${candidate.source}:${start}:${rangeEnd}`,
+          kind: "input_file",
+          source: candidate.source,
+          insertedText,
+          displayName: candidate.displayName,
+          range,
+          metadata: {
+            inputFileId: candidate.file.id ?? null,
+            size: candidate.file.size ?? null,
+            contentType: candidate.file.content_type ?? null,
+            path: candidate.file.path ?? null,
+          },
+        }
+      : {
+          id: `${candidate.sessionId}:${candidate.path}:${start}:${rangeEnd}`,
+          kind: "workspace_file",
+          sessionId: candidate.sessionId,
+          path: candidate.path,
+          insertedText,
+          displayName: candidate.displayName,
+          range,
+          metadata: {
+            size:
+              typeof candidate.file.oss_meta?.size === "number"
+                ? candidate.file.oss_meta.size
+                : null,
+            contentType: candidate.file.mimeType ?? null,
+            sourceKind: candidate.file.source_kind ?? null,
+          },
+        };
 
   return {
     value: nextValue,
     cursor: start + replacement.length,
-    reference: {
-      id: `${candidate.source}:${start}:${rangeEnd}`,
-      kind: "input_file",
-      source: candidate.source,
-      insertedText,
-      displayName: candidate.displayName,
-      range: { start, end: rangeEnd },
-      metadata: {
-        inputFileId: candidate.file.id ?? null,
-        size: candidate.file.size ?? null,
-        contentType: candidate.file.content_type ?? null,
-        path: candidate.file.path ?? null,
-      },
-    },
+    reference,
   };
 }
 
 export function filterInputFileReferences(
-  references: ChatInputFileReference[] | undefined,
+  references: ChatFileReference[] | undefined,
   value: string,
   files: InputFile[],
-): ChatInputFileReference[] {
+  options?: {
+    sessionId?: string | null;
+    workspaceFiles?: FileNode[];
+  },
+): ChatFileReference[] {
   if (!references || references.length === 0) return [];
 
   const availableSources = new Set(
     files.map((file) => normalizeSource(file.source)).filter(Boolean),
   );
-  const nextReferences: ChatInputFileReference[] = [];
+  const availableWorkspacePaths = new Set(
+    flattenWorkspaceFiles(options?.workspaceFiles ?? [])
+      .map((file) => normalizeWorkspacePath(file.path))
+      .filter(Boolean),
+  );
+  const sessionId = (options?.sessionId || "").trim();
+  const shouldCheckWorkspacePaths = availableWorkspacePaths.size > 0;
+  const nextReferences: ChatFileReference[] = [];
 
   for (const reference of references) {
-    const source = normalizeSource(reference.source);
     const insertedText = reference.insertedText.trim();
-    if (!source || !availableSources.has(source) || !insertedText) continue;
+    if (!insertedText) continue;
+
+    if (reference.kind === "input_file") {
+      const source = normalizeSource(reference.source);
+      if (!source || !availableSources.has(source)) continue;
+    } else if (reference.kind === "workspace_file") {
+      if (sessionId && reference.sessionId !== sessionId) continue;
+      const path = normalizeWorkspacePath(reference.path);
+      if (!path) continue;
+      if (shouldCheckWorkspacePaths && !availableWorkspacePaths.has(path)) {
+        continue;
+      }
+    }
 
     const start = value.indexOf(insertedText);
     if (start === -1) continue;

--- a/frontend/features/chat/lib/input-file-reference.ts
+++ b/frontend/features/chat/lib/input-file-reference.ts
@@ -16,16 +16,14 @@ interface BaseInputFileReferenceCandidate {
   description: string | null;
 }
 
-export interface UploadedInputFileReferenceCandidate
-  extends BaseInputFileReferenceCandidate {
+export interface UploadedInputFileReferenceCandidate extends BaseInputFileReferenceCandidate {
   kind: "input_file";
   file: InputFile;
   displayName: string;
   source: string;
 }
 
-export interface WorkspaceInputFileReferenceCandidate
-  extends BaseInputFileReferenceCandidate {
+export interface WorkspaceInputFileReferenceCandidate extends BaseInputFileReferenceCandidate {
   kind: "workspace_file";
   file: FileNode;
   sessionId: string;
@@ -103,7 +101,11 @@ function formatWorkspaceDescription(file: FileNode): string | null {
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-function matchesQuery(displayName: string, path: string, query: string): boolean {
+function matchesQuery(
+  displayName: string,
+  path: string,
+  query: string,
+): boolean {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return true;
   return (

--- a/frontend/features/chat/services/message-parser.test.ts
+++ b/frontend/features/chat/services/message-parser.test.ts
@@ -58,3 +58,48 @@ test("parseMessages leaves plain user messages without triggerContext", () => {
   assert.equal(parsed.messages.length, 1);
   assert.equal(parsed.messages[0].metadata?.triggerContext, undefined);
 });
+
+test("parseMessages maps file_references metadata onto user messages", () => {
+  const fileReferences = [
+    {
+      id: "s3-key:7:18",
+      kind: "input_file",
+      source: "uploads/session/report.md",
+      insertedText: "#report.md",
+      displayName: "report.md",
+      metadata: {
+        path: "/inputs/report.md",
+      },
+    },
+    {
+      id: "session-1:/notes/agent.md:19:30",
+      kind: "workspace_file",
+      sessionId: "session-1",
+      path: "/notes/agent.md",
+      insertedText: "#agent.md",
+      displayName: "agent.md",
+    },
+  ];
+
+  const parsed = parseMessages([
+    {
+      id: 44,
+      role: "user",
+      created_at: "2026-05-08T00:00:00Z",
+      updated_at: "2026-05-08T00:00:00Z",
+      content: {
+        _type: "UserMessage",
+        content: [{ _type: "TextBlock", text: "Use #report.md and #agent.md" }],
+        metadata: {
+          file_references: fileReferences,
+        },
+      },
+    },
+  ]);
+
+  assert.equal(parsed.messages.length, 1);
+  assert.deepEqual(
+    parsed.messages[0].metadata?.inputFileReferences,
+    fileReferences,
+  );
+});

--- a/frontend/features/chat/services/message-parser.test.ts
+++ b/frontend/features/chat/services/message-parser.test.ts
@@ -99,7 +99,7 @@ test("parseMessages maps file_references metadata onto user messages", () => {
 
   assert.equal(parsed.messages.length, 1);
   assert.deepEqual(
-    parsed.messages[0].metadata?.inputFileReferences,
+    parsed.messages[0].metadata?.fileReferences,
     fileReferences,
   );
 });

--- a/frontend/features/chat/services/message-parser.test.ts
+++ b/frontend/features/chat/services/message-parser.test.ts
@@ -98,8 +98,5 @@ test("parseMessages maps file_references metadata onto user messages", () => {
   ]);
 
   assert.equal(parsed.messages.length, 1);
-  assert.deepEqual(
-    parsed.messages[0].metadata?.fileReferences,
-    fileReferences,
-  );
+  assert.deepEqual(parsed.messages[0].metadata?.fileReferences, fileReferences);
 });

--- a/frontend/features/chat/services/message-parser.ts
+++ b/frontend/features/chat/services/message-parser.ts
@@ -451,7 +451,7 @@ export function parseMessages(
           timestamp: msg.created_at,
           metadata: {
             triggerContext: extractTriggerContext(contentObj),
-            inputFileReferences: extractFileReferences(contentObj),
+            fileReferences: extractFileReferences(contentObj),
           },
           attachments: msg.attachments ?? undefined,
         });

--- a/frontend/features/chat/services/message-parser.ts
+++ b/frontend/features/chat/services/message-parser.ts
@@ -11,6 +11,7 @@ import type {
   InputFile,
   ConfigSnapshot,
   AgentTriggerContext,
+  ChatFileReference,
 } from "@/features/chat/types";
 
 // ---------------------------------------------------------------------------
@@ -88,6 +89,50 @@ function extractTriggerContext(
   const triggerContext = metadata.trigger_context;
   if (!isRecord(triggerContext)) return undefined;
   return triggerContext as AgentTriggerContext;
+}
+
+function extractFileReferences(
+  contentObj: MessageContentShape,
+): ChatFileReference[] | undefined {
+  const metadata = contentObj.metadata;
+  if (!isRecord(metadata)) return undefined;
+
+  const rawReferences = Array.isArray(metadata.file_references)
+    ? metadata.file_references
+    : Array.isArray(metadata.input_file_references)
+      ? metadata.input_file_references
+      : null;
+  if (!rawReferences) return undefined;
+
+  const references = rawReferences.flatMap((reference) => {
+    if (!isRecord(reference)) return [];
+    if (reference.kind === "input_file") {
+      if (
+        !isNonEmptyString(reference.id) ||
+        !isNonEmptyString(reference.source) ||
+        !isNonEmptyString(reference.insertedText) ||
+        !isNonEmptyString(reference.displayName)
+      ) {
+        return [];
+      }
+      return [reference as ChatFileReference];
+    }
+    if (reference.kind === "workspace_file") {
+      if (
+        !isNonEmptyString(reference.id) ||
+        !isNonEmptyString(reference.sessionId) ||
+        !isNonEmptyString(reference.path) ||
+        !isNonEmptyString(reference.insertedText) ||
+        !isNonEmptyString(reference.displayName)
+      ) {
+        return [];
+      }
+      return [reference as ChatFileReference];
+    }
+    return [];
+  });
+
+  return references.length > 0 ? references : undefined;
 }
 
 function appendAssistantTextBlock(
@@ -406,6 +451,7 @@ export function parseMessages(
           timestamp: msg.created_at,
           metadata: {
             triggerContext: extractTriggerContext(contentObj),
+            inputFileReferences: extractFileReferences(contentObj),
           },
           attachments: msg.attachments ?? undefined,
         });

--- a/frontend/features/chat/types/api/session-queue-item.ts
+++ b/frontend/features/chat/types/api/session-queue-item.ts
@@ -1,4 +1,4 @@
-import type { InputFile } from "./session";
+import type { ChatFileReference, InputFile } from "./session";
 
 export interface SessionQueueItemResponse {
   queue_item_id: string;
@@ -8,6 +8,8 @@ export interface SessionQueueItemResponse {
   prompt: string;
   permission_mode: string;
   attachments: InputFile[];
+  file_references?: ChatFileReference[] | null;
+  input_file_references?: ChatFileReference[] | null;
   client_request_id?: string | null;
   linked_run_id?: string | null;
   linked_user_message_id?: number | null;
@@ -18,4 +20,6 @@ export interface SessionQueueItemResponse {
 export interface SessionQueueItemUpdateRequest {
   prompt?: string | null;
   attachments?: InputFile[] | null;
+  file_references?: ChatFileReference[] | null;
+  input_file_references?: ChatFileReference[] | null;
 }

--- a/frontend/features/chat/types/api/session.ts
+++ b/frontend/features/chat/types/api/session.ts
@@ -200,6 +200,26 @@ export interface ChatInputFileReference {
   };
 }
 
+export interface ChatWorkspaceFileReference {
+  [x: string]: unknown;
+  id: string;
+  kind: "workspace_file";
+  sessionId: string;
+  path: string;
+  insertedText: string;
+  displayName: string;
+  range?: ChatInputFileReferenceRange;
+  metadata?: {
+    size?: number | null;
+    contentType?: string | null;
+    sourceKind?: string | null;
+  };
+}
+
+export type ChatFileReference =
+  | ChatInputFileReference
+  | ChatWorkspaceFileReference;
+
 export interface TaskConfig {
   repo_url?: string | null;
   git_branch?: string; // defaults to "main"
@@ -238,6 +258,7 @@ export interface TaskConfig {
   filesystem_mode?: FilesystemMode;
   local_mounts?: LocalMountConfig[];
   input_files?: InputFile[];
-  input_file_references?: ChatInputFileReference[];
+  file_references?: ChatFileReference[];
+  input_file_references?: ChatFileReference[];
   trigger_context?: Record<string, unknown> | null;
 }

--- a/frontend/features/chat/types/api/session.ts
+++ b/frontend/features/chat/types/api/session.ts
@@ -179,6 +179,27 @@ export interface InputFile {
   url?: string | null;
 }
 
+export interface ChatInputFileReferenceRange {
+  start: number;
+  end: number;
+}
+
+export interface ChatInputFileReference {
+  [x: string]: unknown;
+  id: string;
+  kind: "input_file";
+  source: string;
+  insertedText: string;
+  displayName: string;
+  range?: ChatInputFileReferenceRange;
+  metadata?: {
+    inputFileId?: string | null;
+    size?: number | null;
+    contentType?: string | null;
+    path?: string | null;
+  };
+}
+
 export interface TaskConfig {
   repo_url?: string | null;
   git_branch?: string; // defaults to "main"
@@ -217,5 +238,6 @@ export interface TaskConfig {
   filesystem_mode?: FilesystemMode;
   local_mounts?: LocalMountConfig[];
   input_files?: InputFile[];
+  input_file_references?: ChatInputFileReference[];
   trigger_context?: Record<string, unknown> | null;
 }

--- a/frontend/features/chat/types/ui/chat.ts
+++ b/frontend/features/chat/types/ui/chat.ts
@@ -1,4 +1,4 @@
-import type { ChatInputFileReference, InputFile } from "../api/session";
+import type { ChatFileReference, InputFile } from "../api/session";
 
 /**
  * Chat-related UI types (frontend-specific)
@@ -93,7 +93,7 @@ export type ChatMessage = {
     duration?: number;
     toolCalls?: ToolCall[];
     triggerContext?: AgentTriggerContext;
-    inputFileReferences?: ChatInputFileReference[];
+    inputFileReferences?: ChatFileReference[];
   };
   parentId?: string;
   attachments?: InputFile[];

--- a/frontend/features/chat/types/ui/chat.ts
+++ b/frontend/features/chat/types/ui/chat.ts
@@ -93,6 +93,7 @@ export type ChatMessage = {
     duration?: number;
     toolCalls?: ToolCall[];
     triggerContext?: AgentTriggerContext;
+    fileReferences?: ChatFileReference[];
     inputFileReferences?: ChatFileReference[];
   };
   parentId?: string;

--- a/frontend/features/chat/types/ui/chat.ts
+++ b/frontend/features/chat/types/ui/chat.ts
@@ -1,4 +1,4 @@
-import type { InputFile } from "../api/session";
+import type { ChatInputFileReference, InputFile } from "../api/session";
 
 /**
  * Chat-related UI types (frontend-specific)
@@ -93,6 +93,7 @@ export type ChatMessage = {
     duration?: number;
     toolCalls?: ToolCall[];
     triggerContext?: AgentTriggerContext;
+    inputFileReferences?: ChatInputFileReference[];
   };
   parentId?: string;
   attachments?: InputFile[];

--- a/frontend/features/task-composer/api/task-submit-api.ts
+++ b/frontend/features/task-composer/api/task-submit-api.ts
@@ -32,6 +32,9 @@ function buildTaskConfig(
   if (inputFiles.length > 0) {
     config.input_files = inputFiles;
   }
+  if ((options.input_file_references?.length ?? 0) > 0) {
+    config.input_file_references = options.input_file_references;
+  }
   if (repoUrl) {
     config.repo_url = repoUrl;
     config.git_branch = gitBranch;

--- a/frontend/features/task-composer/api/task-submit-api.ts
+++ b/frontend/features/task-composer/api/task-submit-api.ts
@@ -32,8 +32,10 @@ function buildTaskConfig(
   if (inputFiles.length > 0) {
     config.input_files = inputFiles;
   }
-  if ((options.input_file_references?.length ?? 0) > 0) {
-    config.input_file_references = options.input_file_references;
+  const fileReferences =
+    options.file_references ?? options.input_file_references ?? [];
+  if (fileReferences.length > 0) {
+    config.file_references = fileReferences;
   }
   if (repoUrl) {
     config.repo_url = repoUrl;

--- a/frontend/features/task-composer/components/task-composer.tsx
+++ b/frontend/features/task-composer/components/task-composer.tsx
@@ -789,7 +789,7 @@ export function TaskComposer({
                   const selected = idx === fileReferenceActiveIndex;
                   return (
                     <button
-                      key={item.source}
+                      key={item.id}
                       type="button"
                       onMouseEnter={() => setFileReferenceActiveIndex(idx)}
                       onMouseDown={(event) => {

--- a/frontend/features/task-composer/components/task-composer.tsx
+++ b/frontend/features/task-composer/components/task-composer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Sparkles, Upload } from "lucide-react";
+import { FileText, Sparkles, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useT } from "@/lib/i18n/client";
 import { Textarea } from "@/components/ui/textarea";
@@ -36,6 +36,12 @@ import { useFileUpload } from "@/features/task-composer/hooks/use-file-upload";
 import { appendTranscribedText, useVoiceInput } from "@/features/voice";
 import { playInstallSound } from "@/lib/utils/sound";
 import { useCapabilityToggle } from "@/features/connectors";
+import {
+  filterInputFileReferences,
+  getInputFileReferenceCandidates,
+  getInputFileReferenceTrigger,
+  insertInputFileReference,
+} from "@/features/chat/lib/input-file-reference";
 import type { RunScheduleMode } from "@/features/task-composer/model/run-schedule";
 import type {
   ComposerMode,
@@ -43,6 +49,7 @@ import type {
   RepoUsageMode,
   TaskSendOptions,
 } from "@/features/task-composer/types";
+import type { ChatInputFileReference } from "@/features/chat/types/api/session";
 import type { CapabilityRecommendation } from "@/features/task-composer/types/capability-recommendation";
 import type { Preset } from "@/features/capabilities/presets/lib/preset-types";
 
@@ -148,20 +155,103 @@ export function TaskComposer({
     disabled: Boolean(isSubmitting) || upload.isUploading,
     onFilesDrop: upload.uploadFiles,
   });
+  const [inputFileReferences, setInputFileReferences] = React.useState<
+    ChatInputFileReference[]
+  >([]);
+  const [selectionStart, setSelectionStart] = React.useState(0);
+  const [fileReferenceActiveIndex, setFileReferenceActiveIndex] =
+    React.useState(0);
+
+  const handleValueChange = React.useCallback(
+    (nextValue: string) => {
+      onChange(nextValue);
+      setInputFileReferences((current) =>
+        filterInputFileReferences(current, nextValue, upload.attachments),
+      );
+    },
+    [onChange, upload.attachments],
+  );
 
   // ---- Slash-command autocomplete ----
   const slashAutocomplete = useSlashCommandAutocomplete({
     value,
-    onChange,
+    onChange: handleValueChange,
     textareaRef,
   });
+
+  const inputFileReferenceTrigger = React.useMemo(
+    () => getInputFileReferenceTrigger(value, selectionStart),
+    [selectionStart, value],
+  );
+  const inputFileReferenceCandidates = React.useMemo(
+    () =>
+      inputFileReferenceTrigger
+        ? getInputFileReferenceCandidates(
+            upload.attachments,
+            inputFileReferenceTrigger.query,
+          )
+        : [],
+    [inputFileReferenceTrigger, upload.attachments],
+  );
+  const isInputFileReferenceOpen =
+    !slashAutocomplete.isOpen &&
+    Boolean(inputFileReferenceTrigger) &&
+    inputFileReferenceCandidates.length > 0;
+
+  React.useEffect(() => {
+    setFileReferenceActiveIndex(0);
+  }, [inputFileReferenceTrigger?.query, inputFileReferenceCandidates.length]);
+
+  React.useEffect(() => {
+    setInputFileReferences((current) =>
+      filterInputFileReferences(current, value, upload.attachments),
+    );
+  }, [upload.attachments, value]);
+
+  const applyInputFileReferenceSelection = React.useCallback(
+    (index: number) => {
+      const candidate = inputFileReferenceCandidates[index];
+      const textarea = textareaRef.current;
+      if (!candidate || !textarea) return;
+
+      const result = insertInputFileReference(
+        value,
+        textarea.selectionStart,
+        textarea.selectionEnd,
+        candidate,
+      );
+      if (!result) return;
+
+      handleValueChange(result.value);
+      setSelectionStart(result.cursor);
+      setInputFileReferences((current) => [
+        ...filterInputFileReferences(
+          current,
+          result.value,
+          upload.attachments,
+        ),
+        result.reference,
+      ]);
+      requestAnimationFrame(() => {
+        textarea.focus();
+        textarea.setSelectionRange(result.cursor, result.cursor);
+      });
+    },
+    [
+      handleValueChange,
+      inputFileReferenceCandidates,
+      textareaRef,
+      upload.attachments,
+      value,
+    ],
+  );
   const voiceInput = useVoiceInput({
     t,
     language: lng,
     onTranscription: React.useCallback(
       (text: string) => {
         const nextValue = appendTranscribedText(latestValueRef.current, text);
-        onChange(nextValue);
+        handleValueChange(nextValue);
 
         requestAnimationFrame(() => {
           const textarea = textareaRef.current;
@@ -170,7 +260,7 @@ export function TaskComposer({
           textarea.setSelectionRange(nextValue.length, nextValue.length);
         });
       },
-      [onChange, textareaRef],
+      [handleValueChange, textareaRef],
     ),
   });
 
@@ -390,6 +480,17 @@ export function TaskComposer({
     repoUrl,
   ]);
 
+  const handleRemoveAttachment = React.useCallback(
+    (index: number) => {
+      const nextAttachments = upload.attachments.filter((_, i) => i !== index);
+      upload.removeAttachment(index);
+      setInputFileReferences((current) =>
+        filterInputFileReferences(current, value, nextAttachments),
+      );
+    },
+    [upload, value],
+  );
+
   const canSubmit = React.useMemo(() => {
     if (mode === "scheduled") {
       return Boolean(value.trim()) && Boolean(scheduledCron.trim());
@@ -413,8 +514,14 @@ export function TaskComposer({
       return;
     }
 
+    const currentInputFileReferences = filterInputFileReferences(
+      inputFileReferences,
+      value,
+      upload.attachments,
+    );
     const payload: TaskSendOptions = {
       attachments: upload.attachments,
+      input_file_references: currentInputFileReferences,
       repo_url: repoUrl.trim() || null,
       git_branch: gitBranch.trim() || null,
       git_token_env_key: repoUrl.trim() ? gitTokenEnvKey.trim() || null : null,
@@ -461,6 +568,7 @@ export function TaskComposer({
 
     onSend(payload);
     upload.clearAttachments();
+    setInputFileReferences([]);
     setRunScheduleMode("immediate");
     setRunScheduledAt(null);
   }, [
@@ -469,6 +577,7 @@ export function TaskComposer({
     canSubmit,
     gitBranch,
     gitTokenEnvKey,
+    inputFileReferences,
     isSubmitting,
     memoryEnabled,
     memoryFeatureEnabled,
@@ -580,7 +689,7 @@ export function TaskComposer({
           attachments={upload.attachments}
           onOpenRepoDialog={() => setRepoDialogOpen(true)}
           onRemoveRepo={() => setRepoUrl("")}
-          onRemoveAttachment={upload.removeAttachment}
+          onRemoveAttachment={handleRemoveAttachment}
         />
 
         {/* Repo dialog */}
@@ -673,11 +782,54 @@ export function TaskComposer({
             onHover={slashAutocomplete.setActiveIndex}
             onSelect={slashAutocomplete.applySelection}
           />
+          {isInputFileReferenceOpen ? (
+            <div className="absolute bottom-full left-0 z-50 mb-2 w-full overflow-hidden rounded-lg border border-border bg-popover shadow-md">
+              <div className="max-h-64 overflow-auto py-1">
+                {inputFileReferenceCandidates.map((item, idx) => {
+                  const selected = idx === fileReferenceActiveIndex;
+                  return (
+                    <button
+                      key={item.source}
+                      type="button"
+                      onMouseEnter={() => setFileReferenceActiveIndex(idx)}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        applyInputFileReferenceSelection(idx);
+                      }}
+                      className={cn(
+                        "flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left text-sm",
+                        selected
+                          ? "bg-accent text-accent-foreground"
+                          : "hover:bg-accent/50",
+                      )}
+                    >
+                      <FileText className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium">
+                          #{item.displayName}
+                        </span>
+                        {item.description ? (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {item.description}
+                          </span>
+                        ) : null}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
           <Textarea
             ref={textareaRef}
             value={value}
             disabled={isSubmitting}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={(e) => {
+              handleValueChange(e.target.value);
+              setSelectionStart(e.target.selectionStart);
+            }}
+            onClick={(e) => setSelectionStart(e.currentTarget.selectionStart)}
+            onKeyUp={(e) => setSelectionStart(e.currentTarget.selectionStart)}
             onCompositionStart={() => (isComposing.current = true)}
             onCompositionEnd={() => {
               requestAnimationFrame(() => {
@@ -693,6 +845,35 @@ export function TaskComposer({
                 e.stopPropagation();
                 onModeChange(getNextComposerMode(mode));
                 return;
+              }
+              if (isInputFileReferenceOpen) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setFileReferenceActiveIndex((current) =>
+                    Math.min(
+                      current + 1,
+                      inputFileReferenceCandidates.length - 1,
+                    ),
+                  );
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setFileReferenceActiveIndex((current) =>
+                    Math.max(current - 1, 0),
+                  );
+                  return;
+                }
+                if (e.key === "Enter" || e.key === "Tab") {
+                  e.preventDefault();
+                  applyInputFileReferenceSelection(fileReferenceActiveIndex);
+                  return;
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setSelectionStart(-1);
+                  return;
+                }
               }
               if (slashAutocomplete.handleKeyDown(e)) return;
               if (e.key === "Enter") {

--- a/frontend/features/task-composer/components/task-composer.tsx
+++ b/frontend/features/task-composer/components/task-composer.tsx
@@ -225,11 +225,7 @@ export function TaskComposer({
       handleValueChange(result.value);
       setSelectionStart(result.cursor);
       setInputFileReferences((current) => [
-        ...filterInputFileReferences(
-          current,
-          result.value,
-          upload.attachments,
-        ),
+        ...filterInputFileReferences(current, result.value, upload.attachments),
         result.reference,
       ]);
       requestAnimationFrame(() => {

--- a/frontend/features/task-composer/components/task-composer.tsx
+++ b/frontend/features/task-composer/components/task-composer.tsx
@@ -49,7 +49,7 @@ import type {
   RepoUsageMode,
   TaskSendOptions,
 } from "@/features/task-composer/types";
-import type { ChatInputFileReference } from "@/features/chat/types/api/session";
+import type { ChatFileReference } from "@/features/chat/types/api/session";
 import type { CapabilityRecommendation } from "@/features/task-composer/types/capability-recommendation";
 import type { Preset } from "@/features/capabilities/presets/lib/preset-types";
 
@@ -156,7 +156,7 @@ export function TaskComposer({
     onFilesDrop: upload.uploadFiles,
   });
   const [inputFileReferences, setInputFileReferences] = React.useState<
-    ChatInputFileReference[]
+    ChatFileReference[]
   >([]);
   const [selectionStart, setSelectionStart] = React.useState(0);
   const [fileReferenceActiveIndex, setFileReferenceActiveIndex] =
@@ -521,7 +521,7 @@ export function TaskComposer({
     );
     const payload: TaskSendOptions = {
       attachments: upload.attachments,
-      input_file_references: currentInputFileReferences,
+      file_references: currentInputFileReferences,
       repo_url: repoUrl.trim() || null,
       git_branch: gitBranch.trim() || null,
       git_token_env_key: repoUrl.trim() ? gitTokenEnvKey.trim() || null : null,

--- a/frontend/features/task-composer/types/index.ts
+++ b/frontend/features/task-composer/types/index.ts
@@ -1,5 +1,6 @@
 import type { AddTaskOptions } from "@/features/projects/types";
 import type {
+  ChatInputFileReference,
   InputFile,
   LocalMountConfig,
 } from "@/features/chat/types/api/session";
@@ -16,6 +17,7 @@ export type RepoUsageMode = "session" | "create_project";
 
 export interface TaskSendOptions {
   attachments?: InputFile[];
+  input_file_references?: ChatInputFileReference[];
   repo_url?: string | null;
   git_branch?: string | null;
   git_token_env_key?: string | null;

--- a/frontend/features/task-composer/types/index.ts
+++ b/frontend/features/task-composer/types/index.ts
@@ -1,6 +1,6 @@
 import type { AddTaskOptions } from "@/features/projects/types";
 import type {
-  ChatInputFileReference,
+  ChatFileReference,
   InputFile,
   LocalMountConfig,
 } from "@/features/chat/types/api/session";
@@ -17,7 +17,8 @@ export type RepoUsageMode = "session" | "create_project";
 
 export interface TaskSendOptions {
   attachments?: InputFile[];
-  input_file_references?: ChatInputFileReference[];
+  file_references?: ChatFileReference[];
+  input_file_references?: ChatFileReference[];
   repo_url?: string | null;
   git_branch?: string | null;
   git_token_env_key?: string | null;

--- a/specs/active/33-executor-manager-workspace-authorization-hardening-plan.md
+++ b/specs/active/33-executor-manager-workspace-authorization-hardening-plan.md
@@ -1,0 +1,512 @@
+# Executor Manager API authentication hardening plan
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **创建日期** | 2026-06-11 |
+| **预期改动范围** | executor_manager API auth dependencies / backend EM clients / executor callback clients / tests / deployment notes |
+| **改动类型** | fix / security-hardening |
+| **优先级** | P0 |
+| **状态** | implemented |
+| **关联 issue** | `poco-ai/poco-claw#133` |
+| **关联 constitution** | `specs/constitution/2026-06-11-executor-manager-workspace-authorization.md` |
+
+## 实施阶段
+
+- [x] Phase 0: 路由盘点与失败测试
+- [x] Phase 1: 内部控制面接口补 `X-Internal-Token`
+- [x] Phase 2: Executor 回传/工具代理接口补 callback token
+- [x] Phase 3: 用户态功能和部署边界回归
+- [x] Phase 4: 验证、文档回写和后续加固记录
+
+---
+
+## 背景
+
+### 问题陈述
+
+`poco-ai/poco-claw#133` 报告的是 Executor Manager 的 `/api/v1/workspace/*` 没有鉴权，导致调用方可以通过 URL 中的 `user_id/session_id/path` 访问别人的执行 workspace。
+
+复查 EM 路由后，问题不只是一条 workspace file route。当前 EM 中只有少数接口已经有 token：
+
+- `/api/v1/internal/runs/notify` 已有 `X-Internal-Token`。
+- `/api/v1/skills/submit` 已有 callback token。
+
+其余多组接口在 HTTP 层没有 token。为了避免只补 issue PoC 而留下同类裸控制面，本计划按调用方分两步补齐：
+
+1. Backend/internal service 调 EM 的控制面接口使用 `X-Internal-Token`。
+2. Executor container 调 EM 的回传/工具代理接口使用 callback token。
+
+### 目标
+
+- `/api/v1/workspace/*` 直接无 token 访问返回 `403`。
+- `/api/v1/tasks`、`/api/v1/executor/*`、`/api/v1/schedules` 只有带 `X-Internal-Token` 的内部调用可以访问。
+- `/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories`、`/api/v1/agent-channel-*`、`/api/v1/user-input-requests` 只有带 callback token 的 executor 可以访问。
+- Backend 用户态 `/sessions/{session_id}/workspace/*`、`/runs/{run_id}/workspace/*` 体验不变。
+- 不把 `INTERNAL_API_TOKEN` 暴露给 executor container。
+- 不把 callback token 授予控制面能力。
+
+### 非目标
+
+- 不在 v1 引入 session-scoped workspace capability。
+- 不重做 Backend 用户态 session/run 鉴权。
+- 不改变 workspace export manifest 格式。
+- 不改变 share link、share to channel、channel artifacts 的产品语义。
+- 不在本轮解决多 EM 部署下的 token rotation/revocation。
+
+---
+
+## Phase 0: 路由盘点与失败测试
+
+### 目标
+
+先把当前裸接口和预期鉴权方式固定下来，避免实现时漏掉调用方同步。
+
+### 任务清单
+
+#### 0.1 固定 EM 路由鉴权矩阵
+
+**描述：** 在测试或文档注释中固定以下分类，作为实现检查表。
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/__init__.py`
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+- `executor_manager/app/api/v1/skills_upload.py`
+- `executor_manager/app/api/v1/internal_runs.py`
+
+**验收标准：**
+
+- [x] health/root route 明确保持无 token。
+- [x] `/internal/runs/notify` 明确保持 `X-Internal-Token`。
+- [x] `/skills/submit` 明确保持 callback token。
+- [x] workspace/tasks/executor/schedules 明确归类为 internal control plane。
+- [x] callback/computer/memories/agent-channel/user-input 明确归类为 executor callback/tool proxy。
+
+#### 0.2 增加 control plane 鉴权失败测试
+
+**描述：** 新增或扩展 EM API auth 测试，先证明无 token 访问会失败。
+
+**涉及文件：**
+
+- 新增 `executor_manager/tests/test_control_plane_auth.py`
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+
+**建议用例：**
+
+- `GET /api/v1/workspace/file/victim/{session}?path=secret.txt` without token returns `403`
+- `GET /api/v1/workspace/files/victim/{session}` without token returns `403`
+- `POST /api/v1/workspace/archive/victim/{session}` without token returns `403`
+- `DELETE /api/v1/workspace/victim/{session}` without token returns `403`
+- `POST /api/v1/tasks` without token returns `403`
+- `POST /api/v1/executor/delete` without token returns `403`
+- `GET /api/v1/executor/load` without token returns `403`
+- `GET /api/v1/schedules` without token returns `403`
+- `GET /api/v1/health` still returns `200`
+
+**验收标准：**
+
+- [x] 当前未修复代码下这些测试能暴露缺口。
+- [x] 修复后全部返回预期状态。
+- [x] 测试不依赖 Docker daemon 或真实 object storage。
+
+#### 0.3 增加 executor proxy 鉴权失败测试
+
+**描述：** 覆盖 executor 回传/工具代理接口，未带 callback token 应返回 `403`。
+
+**涉及文件：**
+
+- 新增 `executor_manager/tests/test_executor_proxy_auth.py`
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+
+**建议用例：**
+
+- `POST /api/v1/callback` without bearer token returns `403`
+- `POST /api/v1/computer/screenshots` without bearer token returns `403`
+- `POST /api/v1/memories` without bearer token returns `403`
+- `POST /api/v1/agent-channel-runtime/messages/read` without bearer token returns `403`
+- `POST /api/v1/agent-channel-artifacts/list` without bearer token returns `403`
+- `POST /api/v1/agent-channel-tasks/list` without bearer token returns `403`
+- `POST /api/v1/user-input-requests` without bearer token returns `403`
+- same endpoints with valid callback token preserve existing behavior through mocked services
+
+**验收标准：**
+
+- [x] 无 token 请求全部拒绝。
+- [x] 带合法 callback token 请求不破坏现有 mock/service 调用。
+- [x] `/api/v1/skills/submit` 继续通过现有 callback token 测试。
+
+---
+
+## Phase 1: 内部控制面接口补 `X-Internal-Token`
+
+### 目标
+
+把 Backend/internal service 调用的 EM 控制面接口收成 internal-only。
+
+### 任务清单
+
+#### 1.1 给 control plane routers 加 `require_internal_token`
+
+**描述：** 给以下 router 或 route 增加 `Depends(require_internal_token)`：
+
+- `/api/v1/workspace/*`
+- `/api/v1/tasks`
+- `/api/v1/executor/*`
+- `/api/v1/schedules`
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/workspace.py`
+- `executor_manager/app/api/v1/tasks.py`
+- `executor_manager/app/api/v1/executor.py`
+- `executor_manager/app/api/v1/schedules.py`
+- `executor_manager/app/core/deps.py`
+- `executor_manager/tests/test_control_plane_auth.py`
+
+**验收标准：**
+
+- [x] 无 `X-Internal-Token` 时返回 `403`。
+- [x] 错误 `X-Internal-Token` 时返回 `403`。
+- [x] 正确 `X-Internal-Token` 时保持原有功能。
+- [x] health/root route 不受影响。
+
+#### 1.2 更新 Backend 调 EM 的 control plane client
+
+**描述：** Backend 调 EM control plane 时必须带 `X-Internal-Token`。
+
+**涉及文件：**
+
+- `backend/app/services/executor_manager_client.py`
+- `backend/app/api/v1/schedules.py`
+- 可能涉及创建任务的 Backend service/client 调用路径
+- `backend/tests/test_executor_manager_notify_service.py`
+- 新增或扩展 `backend/tests/test_executor_manager_client.py`
+
+**验收标准：**
+
+- [x] `ExecutorManagerClient.delete_container()` 请求 `/api/v1/executor/delete` 时带 `X-Internal-Token`。
+- [x] Backend schedules proxy 请求 `/api/v1/schedules` 时带 `X-Internal-Token`。
+- [x] 如果 Backend 仍直接请求 `/api/v1/tasks`，该请求也带 `X-Internal-Token`。
+- [x] 既有 `/api/v1/internal/runs/notify` 调用继续带 `X-Internal-Token`。
+
+#### 1.3 保留 workspace 产品入口在 Backend
+
+**描述：** 不把前端文件浏览改到 EM；只加固 EM 底层接口。
+
+**涉及文件：**
+
+- `backend/app/api/v1/sessions.py`
+- `backend/app/api/v1/runs.py`
+- `frontend/features/chat/api/chat-api.ts`
+- `frontend/services/api-client.ts`
+
+**验收标准：**
+
+- [x] Frontend `chatService.getFiles()` 继续走 `/sessions/{session_id}/workspace/files`。
+- [x] Frontend `chatService.getRunFiles()` 继续走 `/runs/{run_id}/workspace/files`。
+- [x] Backend session/run workspace owner check 保持在读取 manifest 和生成 presigned URL 之前。
+
+---
+
+## Phase 2: Executor 回传/工具代理接口补 callback token
+
+### 目标
+
+把 executor container 调 EM 的回传和工具代理接口收成 callback-token-only，同时同步 executor client，避免执行链路被打断。
+
+### 任务清单
+
+#### 2.1 给 executor proxy routers 加 `require_callback_token`
+
+**描述：** 给以下 router 或 route 增加 `Depends(require_callback_token)`：
+
+- `/api/v1/callback`
+- `/api/v1/computer/screenshots`
+- `/api/v1/memories`
+- `/api/v1/agent-channel-runtime/*`
+- `/api/v1/agent-channel-artifacts/*`
+- `/api/v1/agent-channel-tasks/*`
+- `/api/v1/user-input-requests`
+
+**涉及文件：**
+
+- `executor_manager/app/api/v1/callback.py`
+- `executor_manager/app/api/v1/computer.py`
+- `executor_manager/app/api/v1/memories.py`
+- `executor_manager/app/api/v1/agent_channel_runtime.py`
+- `executor_manager/app/api/v1/agent_channel_artifacts.py`
+- `executor_manager/app/api/v1/agent_channel_tasks.py`
+- `executor_manager/app/api/v1/user_input_requests.py`
+- `executor_manager/app/core/deps.py`
+- `executor_manager/tests/test_executor_proxy_auth.py`
+
+**验收标准：**
+
+- [x] 无 `Authorization: Bearer <callback_token>` 时返回 `403`。
+- [x] 错误 callback token 时返回 `403`。
+- [x] 正确 callback token 时保持原有转发和上传行为。
+- [x] `/api/v1/skills/submit` 保持现有 callback token 鉴权，不重复实现。
+
+#### 2.2 Executor clients 统一带 callback token
+
+**描述：** executor 侧所有调 EM 的回传/工具 client 都要带 `Authorization: Bearer <callback_token>`。
+
+**涉及文件：**
+
+- `executor/app/api/v1/task.py`
+- `executor/app/core/callback.py`
+- `executor/app/core/computer.py`
+- `executor/app/core/memory.py`
+- `executor/app/core/channel_runtime.py`
+- `executor/app/core/user_input.py`
+- `executor/tests/test_channel_runtime_tools.py`
+- 新增或扩展 executor client auth tests
+
+**验收标准：**
+
+- [x] `CallbackClient` 初始化时接收 callback token，并在 `/api/v1/callback` 请求中发送 Bearer token。
+- [x] `ComputerClient` 初始化时接收 callback token，并在 screenshot upload 请求中发送 Bearer token。
+- [x] `MemoryClient` 初始化时接收 callback token，并在 memory proxy 请求中发送 Bearer token。
+- [x] `ChannelRuntimeClient` 初始化时接收 callback token，并在 runtime/artifact/task proxy 请求中发送 Bearer token。
+- [x] `UserInputClient` 初始化时接收 callback token，并在 user input 请求中发送 Bearer token。
+- [x] `executor/app/api/v1/task.py` 从 `TaskRun.callback_token` 传给上述 client。
+
+#### 2.3 保持 callback token 不进入控制面
+
+**描述：** callback token 只能用于 executor 回传/工具代理接口，不能用于 `/tasks`、`/executor/*`、`/workspace/*`、`/schedules`。
+
+**涉及文件：**
+
+- `executor_manager/tests/test_control_plane_auth.py`
+- `executor_manager/tests/test_executor_proxy_auth.py`
+
+**验收标准：**
+
+- [x] 用 callback token 调 `/api/v1/workspace/stats` 返回 `403`。
+- [x] 用 callback token 调 `/api/v1/tasks` 返回 `403`。
+- [x] 用 callback token 调 `/api/v1/executor/delete` 返回 `403`。
+- [x] 用 internal token 调 `/api/v1/callback` 返回 `403`，除非它恰好等于 callback token。
+
+---
+
+## Phase 3: 用户态功能和部署边界回归
+
+### 目标
+
+确认安全加固不影响正常用户体验，并记录部署边界。
+
+### 任务清单
+
+#### 3.1 Backend 用户态 workspace 回归
+
+**涉及文件：**
+
+- `backend/app/api/v1/sessions.py`
+- `backend/app/api/v1/runs.py`
+- `backend/tests/test_session_share_service.py`
+- 新增或扩展 `backend/tests/test_session_workspace_authorization.py`
+
+**验收标准：**
+
+- [x] owner 可以继续读取 session workspace files。
+- [x] owner 可以继续读取 run workspace files。
+- [x] non-owner 继续返回 `403`。
+- [x] share link public response 不暴露 `workspace_manifest_key`、`workspace_files_prefix`、source session id 或 owner user id。
+
+#### 3.2 Frontend API boundary 回归
+
+**涉及文件：**
+
+- `frontend/features/chat/api/chat-api.ts`
+- `frontend/features/chat/components/execution/file-panel/hooks/use-artifacts.ts`
+- `frontend/services/api-client.ts`
+
+**验收标准：**
+
+- [x] Artifacts panel 仍通过 Backend session/run API 拉文件。
+- [x] Frontend 代码中没有 direct EM `/api/v1/workspace/*` 调用。
+- [x] `pnpm lint` 和 `pnpm build` 通过，或记录明确阻塞。
+
+#### 3.3 部署文档更新
+
+**涉及文件：**
+
+- `README.md` 或部署相关文档
+- `docker-compose.yml`
+- `docker-compose.r2.yml`
+- `.env.example` 类文件，如存在
+
+**验收标准：**
+
+- [x] 文档说明 EM 8001 不应公网暴露。
+- [x] 文档说明 `INTERNAL_API_TOKEN` 供 Backend/internal service 调 EM 控制面。
+- [x] 文档说明 `CALLBACK_TOKEN` 供 executor container 调 EM 回传/工具代理接口。
+- [x] 不把真实 token 写入文档。
+
+---
+
+## Phase 4: 验证、文档回写和后续加固记录
+
+### 目标
+
+跑 targeted tests 和最小静态检查，并把实际结果回写到 spec。
+
+### 任务清单
+
+#### 4.1 Executor Manager 验证
+
+**验证命令：**
+
+```bash
+cd executor_manager
+uv run python -m unittest tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m py_compile app/api/v1/workspace.py app/api/v1/tasks.py app/api/v1/executor.py app/api/v1/schedules.py app/api/v1/callback.py app/api/v1/computer.py app/api/v1/memories.py app/api/v1/agent_channel_runtime.py app/api/v1/agent_channel_artifacts.py app/api/v1/agent_channel_tasks.py app/api/v1/user_input_requests.py app/core/deps.py
+uv run ruff check app/api/v1/workspace.py app/api/v1/tasks.py app/api/v1/executor.py app/api/v1/schedules.py app/api/v1/callback.py app/api/v1/computer.py app/api/v1/memories.py app/api/v1/agent_channel_runtime.py app/api/v1/agent_channel_artifacts.py app/api/v1/agent_channel_tasks.py app/api/v1/user_input_requests.py tests/test_control_plane_auth.py tests/test_executor_proxy_auth.py
+```
+
+**验收标准：**
+
+- [x] workspace PoC 无 token 返回 `403`。
+- [x] control plane 只有 internal token 可访问。
+- [x] executor proxy 只有 callback token 可访问。
+- [x] health/root 无 token 可访问。
+
+#### 4.2 Backend / Executor 验证
+
+**验证命令：**
+
+```bash
+cd backend
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy tests.test_executor_manager_notify_service tests.test_agent_assignment_service
+uv run python -m py_compile app/services/executor_manager_client.py app/api/v1/schedules.py app/api/v1/sessions.py app/api/v1/runs.py
+
+cd ../executor
+uv run python -m unittest tests.test_manager_auth_clients tests.test_channel_runtime_tools tests.test_engine_channel_artifact_tools tests.test_engine_channel_reaction_tools tests.test_engine_channel_task_hint tests.test_engine_channel_runtime_hint tests.test_engine_persistent_state_hint
+uv run python -m py_compile app/api/v1/task.py app/core/callback.py app/core/computer.py app/core/memory.py app/core/channel_runtime.py app/core/user_input.py
+```
+
+**验收标准：**
+
+- [x] Backend 调 EM control plane 带 internal token。
+- [x] Executor 调 EM callback/tool proxy 带 callback token。
+- [x] 现有 channel runtime tools 测试通过。
+- [x] session/run workspace 用户态回归通过。
+
+#### 4.3 Frontend 验证
+
+**验证命令：**
+
+```bash
+cd frontend
+rg -n "executor_manager|/api/v1/workspace|workspace/file/" app features services
+```
+
+**验收标准：**
+
+- [x] Frontend 没有 direct EM workspace 调用。
+- [x] 本次未修改 frontend；执行边界扫描即可，未跑 `pnpm lint` / `pnpm build`。
+
+#### 4.4 Spec 回写
+
+**涉及文件：**
+
+- `specs/active/33-executor-manager-workspace-authorization-hardening-plan.md`
+- `specs/constitution/2026-06-11-executor-manager-workspace-authorization.md`
+
+**验收标准：**
+
+- [x] 完成 phase 标记为 `[x]`。
+- [x] 写入实际验证命令和结果。
+- [x] 如果实现中改变接口分类，更新 constitution 的 EM API 分类表。
+- [x] 记录后续更细粒度加固项：session-scoped capability、token rotation、生产默认 token fail-fast。
+
+---
+
+## 实施记录
+
+### 2026-06-11
+
+**实际落地：**
+
+- `workspace/tasks/executor/schedules` 已统一挂 `require_internal_token`。
+- `callback/computer/memories/agent-channel-runtime/agent-channel-artifacts/agent-channel-tasks/user-input-requests` 已统一挂 `require_callback_token`。
+- Backend `ExecutorManagerClient.delete_container()` 和 schedules proxy 已补 `X-Internal-Token`。
+- Executor `CallbackClient`、`ComputerClient`、`MemoryClient`、`ChannelRuntimeClient`、`UserInputClient` 已接收并发送 callback token。
+- `executor/app/api/v1/task.py` 已把 `TaskRun.callback_token` 传给上述 executor client。
+- Frontend 文件浏览仍通过 Backend `/sessions/{session_id}/workspace/files` 和 `/runs/{run_id}/workspace/files`。
+
+**已执行验证：**
+
+```bash
+cd executor_manager
+uv run python -m unittest tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m unittest tests.test_agent_channel_runtime_api tests.test_agent_channel_artifacts_api tests.test_agent_channel_tasks_api tests.test_internal_runs_notify tests.test_control_plane_auth tests.test_executor_proxy_auth
+uv run python -m unittest discover -s tests
+
+cd ../executor
+uv run python -m unittest tests.test_manager_auth_clients
+uv run python -m unittest tests.test_manager_auth_clients tests.test_channel_runtime_tools tests.test_engine_channel_artifact_tools tests.test_engine_channel_reaction_tools tests.test_engine_channel_task_hint tests.test_engine_channel_runtime_hint tests.test_engine_persistent_state_hint
+uv run python -m unittest discover -s tests
+
+cd ../backend
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy
+uv run python -m unittest tests.test_executor_manager_client tests.test_schedules_proxy tests.test_executor_manager_notify_service tests.test_agent_assignment_service
+
+cd ..
+rg -n "executor_manager|/api/v1/workspace|workspace/file/|workspace/files|sessionWorkspaceFiles|runWorkspaceFiles" frontend/app frontend/features frontend/services backend/app/api/v1/sessions.py backend/app/api/v1/runs.py
+```
+
+**验证结果：**
+
+- 上述 `unittest` 命令均通过。
+- `executor_manager` 完整 unittest discover：41 tests passed。
+- `executor` 完整 unittest discover：45 tests passed。
+- Backend targeted unittest：8 tests passed。
+- `pytest` 当前未安装在各服务 venv 中，因此本轮按仓库现有 `unittest` 测试风格验证。
+- Frontend 未改代码；边界扫描确认没有 direct EM workspace 调用，仍走 Backend session/run workspace API。
+
+---
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+| --- | --- | --- |
+| 只给 EM route 加 token，忘记更新调用方 | Backend 或 executor 调用失败 | 每个 phase 都包含调用方同步和测试 |
+| 把 executor proxy 错套 `X-Internal-Token` | executor container 需要拿 internal token，扩大权限 | executor proxy 统一用 callback token |
+| 把 control plane 错套 callback token | executor token 可创建任务或删容器 | control plane 统一用 internal token，并测试 callback token 不可访问 |
+| EM 8001 仍公网暴露 | 攻击面仍大 | 代码 fail closed + 部署文档明确不公网暴露 |
+| 默认 token 未改 | token 等同公开 | 后续加固记录 production fail-fast，文档强调非默认 |
+
+---
+
+## 总结
+
+v1 修复不是“只修 workspace file”，也不是“所有 EM 接口用同一个 token”。正确边界是：
+
+- Backend/internal service 调 EM 控制面：`X-Internal-Token`。
+- Executor container 调 EM 回传/工具代理：callback token。
+- Frontend 继续只调 Backend 用户态 API。
+- Health/root 保持无 token。
+
+这能直接关闭 issue #133 的 workspace 裸接口风险，也把 EM 其他裸接口纳入同一轮可审核的加固计划。

--- a/specs/active/34-ordinary-chat-input-file-reference-plan.md
+++ b/specs/active/34-ordinary-chat-input-file-reference-plan.md
@@ -6,10 +6,10 @@
 | --- | --- |
 | **创建日期** | 2026-06-11 |
 | **修订日期** | 2026-06-12 |
-| **预期改动范围** | frontend chat input / task composer input / chat message rendering / session file APIs / task enqueue payload / backend task schema and message metadata / executor input hint / tests |
+| **预期改动范围** | frontend chat input / task composer input / chat message rendering / session file APIs / task enqueue payload / backend task schema and message metadata / executor workspace reference hint / tests |
 | **改动类型** | feat |
 | **优先级** | P1 |
-| **状态** | in-progress |
+| **状态** | review |
 | **关联 spec** | `specs/active/30-structured-channel-mentions-and-context-references-plan.md` |
 
 ## 修订说明
@@ -21,11 +21,11 @@
 ## 实施阶段
 
 - [x] Phase 0: 保留前端 `#` 输入交互基线
-- [ ] Phase 1: 固定统一会话文件引用契约
-- [ ] Phase 2: 前端候选源扩展为当前会话文件索引
-- [ ] Phase 3: 后端解析引用并提升为本轮 runtime inputs
-- [ ] Phase 4: 历史消息渲染、编辑、重跑和队列项兼容
-- [ ] Phase 5: 验证、回归和文档回写
+- [x] Phase 1: 固定统一会话文件引用契约
+- [x] Phase 2: 前端候选源扩展为当前会话文件索引
+- [x] Phase 3: 后端解析引用并保留 workspace path 语义
+- [x] Phase 4: 历史消息渲染、编辑、重跑和队列项兼容
+- [x] Phase 5: 验证、回归和文档回写
 
 ---
 
@@ -41,15 +41,15 @@
 - 之前用户消息带入的 input files。
 - agent 在当前会话 workspace 中创建、修改并通过 workspace export 暴露的文件。
 
-因此，普通聊天 `#file` 不能只绑定到当前草稿的附件，也不能只把正文 token 传给模型。它必须先解析成结构化会话文件引用，再在后端转换为本轮 runtime 可访问的 `input_files`。Executor Manager 仍然通过既有 `input_files` staging 机制把文件放到 `/workspace/inputs/...`，executor 只看到可访问路径。
+因此，普通聊天 `#file` 不能只绑定到当前草稿的附件，也不能只把正文 token 传给模型。它必须先解析成结构化会话文件引用。对于 agent 已经写入当前 session workspace 的文件，引用语义是“用户正在讨论 `/workspace/...` 中的这个路径”，不是重新上传或复制成 input；只有用户上传附件、历史输入文件这类本来就不在 workspace 正文路径上的对象，才继续走 `input_files` staging。
 
 ### 目标
 
 - 普通聊天输入框支持输入 `#` 后选择当前会话中的文件。
 - 文件候选统一展示，不要求用户知道文件来自上传、历史输入还是 agent workspace 输出。
 - 选择文件后正文插入人类可读 token，例如 `#report.md`。
-- 发送时携带结构化 references；后端解析 references，自动补齐本轮 `input_files`。
-- runtime 仍以 staged `input_files.path` 为准，不让模型依赖 UI token 或 OSS key。
+- 发送时携带结构化 references；后端解析 references，校验 workspace path 或补齐上传 input。
+- workspace 文件引用在 runtime 中以 `/workspace/<path>` 为准，不让模型把它猜成 `/inputs/<path>`；上传/历史 input 文件仍以 staged `input_files.path` 为准。
 - 历史消息可以把已验证的 `#file` 渲染为 file chip。
 - 编辑、重跑和 queued query 更新不能让正文 token 与实际 runtime inputs 脱节。
 
@@ -64,9 +64,9 @@
 
 ### 关键洞察
 
-#### 1. UI 对象应统一，runtime 输入仍可归一到 `input_files`
+#### 1. UI 对象应统一，但 runtime 路径语义不能混成 `input_files`
 
-用户看到的是统一文件对象，后端执行时需要的是 staged input。两者不矛盾：reference 可以保留原始来源类型，后端在 enqueue 前把被引用文件统一提升为本轮 `input_files`。
+用户看到的是统一文件对象，但不同来源的 runtime 语义不同：workspace 文件已经位于会话 workspace，应作为 `/workspace/...` 路径提示给 agent；上传文件和历史 input 文件才需要通过 `input_files` staging 暴露到 `/workspace/inputs/...`。
 
 #### 2. workspace 文件已经有事实源
 
@@ -124,21 +124,16 @@ type ChatFileReference =
 
 后端 schema 与前端字段同构，接收 `TaskConfig.file_references`。为兼容 `ae3623a3` 已落地的前端基线，短期可以继续接受 `input_file_references` 作为 alias，但内部服务应统一转成 `file_references`。
 
-### Runtime 转换
+### Runtime 解析
 
 后端创建 run snapshot 前执行：
 
 1. 合并 project inputs、当前上传 attachments、历史/引用需要的 synthetic inputs。
 2. 对 `input_file` reference，要求 `source` 能在合并后的 input files 中找到。
 3. 对 `workspace_file` reference，要求 session 属于当前用户、workspace export ready、manifest 中存在该 path。
-4. 从 manifest entry 构造 `InputFile`：
-   - `type = "file"`
-   - `name = basename(path)`
-   - `source = manifest entry key`
-   - `size = manifest entry size`
-   - `content_type = manifest entry mimeType`
-   - `path = /inputs/<normalized workspace path without leading slash>`
-5. 保存 `input_files` 和 `file_references` 到 run config snapshot。
+4. `workspace_file` 不构造 `InputFile`，不触发 EM attachment staging；仅保存规范化后的 `/path`。
+5. executor prompt hint 把 `workspace_file` 映射为 `/workspace/<path>`，并明确禁止 agent 猜测 `/inputs/<path>`。
+6. 保存 `input_files`（仅上传/历史/project inputs）和 `file_references` 到 run config snapshot。
 
 ---
 
@@ -175,21 +170,21 @@ type ChatFileReference =
 - 新建任务首页不会请求不存在的 session workspace。
 - 删除正文 token 或删除 draft attachment 会过滤对应 stale reference。
 
-## Phase 3: 后端解析引用并提升为本轮 runtime inputs
+## Phase 3: 后端解析引用并保留 workspace path 语义
 
 ### 任务
 
 - 新增 file reference resolver service。
 - 从 session workspace manifest 解析 workspace file reference。
-- 将 workspace file synthetic input 合并进 run snapshot `input_files`。
-- 确保 executor manager 仍只通过 `input_files` staging。
+- workspace file reference 只校验并保存路径，不合并进 run snapshot `input_files`。
+- 确保 executor manager 只 staging 上传/历史 input，不 staging workspace reference。
 - 让 queued item update 同步过滤/解析 references。
 
 ### 验收
 
 - 引用不存在的 workspace path 返回 400。
 - 引用其他用户/其他 session 文件返回 403 或 400。
-- workspace reference 出现在本轮 `input_files` 后能 staging 到 `/workspace/inputs/...`。
+- workspace reference 不出现在本轮 `input_files`，executor hint 直接指向 `/workspace/...`。
 - 不依赖 preview URL。
 
 ## Phase 4: 历史消息渲染、编辑、重跑和队列项兼容
@@ -223,5 +218,5 @@ type ChatFileReference =
 
 - 在已有会话中让 agent 创建文件。
 - 继续输入下一条消息，输入 `#`，能看到刚创建的文件。
-- 选择该文件发送后，agent 能在 `/workspace/inputs/...` 看到并读取该文件。
-- 历史消息中该引用显示为 file chip。
+- 选择该文件发送后，agent 的 prompt hint 指向 `/workspace/<path>`，agent 首次读取应使用 workspace 路径而不是 `/inputs/...`。
+- 历史消息中该引用在正文内显示为与频道 artifact 一致的 inline file chip。

--- a/specs/active/34-ordinary-chat-input-file-reference-plan.md
+++ b/specs/active/34-ordinary-chat-input-file-reference-plan.md
@@ -1,0 +1,227 @@
+# 普通聊天会话文件引用计划
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **创建日期** | 2026-06-11 |
+| **修订日期** | 2026-06-12 |
+| **预期改动范围** | frontend chat input / task composer input / chat message rendering / session file APIs / task enqueue payload / backend task schema and message metadata / executor input hint / tests |
+| **改动类型** | feat |
+| **优先级** | P1 |
+| **状态** | in-progress |
+| **关联 spec** | `specs/active/30-structured-channel-mentions-and-context-references-plan.md` |
+
+## 修订说明
+
+上一版把普通聊天 `#` 文件引用收窄成“当前草稿上传附件选择器”。这不符合产品目标。真正目标是：普通聊天里 `#` 能引用当前会话中的文件，包括用户上传文件、历史消息输入文件，以及 agent 在 workspace export 中生成的文件。
+
+本版保留已完成的 textarea 交互基础，但重置协议和后端语义：引用对象是统一的会话文件引用，不是仅指向本轮 `input_files` 的轻量注释。
+
+## 实施阶段
+
+- [x] Phase 0: 保留前端 `#` 输入交互基线
+- [ ] Phase 1: 固定统一会话文件引用契约
+- [ ] Phase 2: 前端候选源扩展为当前会话文件索引
+- [ ] Phase 3: 后端解析引用并提升为本轮 runtime inputs
+- [ ] Phase 4: 历史消息渲染、编辑、重跑和队列项兼容
+- [ ] Phase 5: 验证、回归和文档回写
+
+---
+
+## 背景
+
+### 问题陈述
+
+频道聊天已经有 `@` / `#` 双入口，`#` 可以引用 channel artifact、task、thread 等频道上下文对象。普通聊天也需要类似的文件引用能力，但普通聊天没有频道 runtime tools，也没有 published artifact scope。
+
+普通聊天中用户真正想引用的是“这个会话里能看到的文件”：
+
+- 当前草稿刚上传的文件。
+- 之前用户消息带入的 input files。
+- agent 在当前会话 workspace 中创建、修改并通过 workspace export 暴露的文件。
+
+因此，普通聊天 `#file` 不能只绑定到当前草稿的附件，也不能只把正文 token 传给模型。它必须先解析成结构化会话文件引用，再在后端转换为本轮 runtime 可访问的 `input_files`。Executor Manager 仍然通过既有 `input_files` staging 机制把文件放到 `/workspace/inputs/...`，executor 只看到可访问路径。
+
+### 目标
+
+- 普通聊天输入框支持输入 `#` 后选择当前会话中的文件。
+- 文件候选统一展示，不要求用户知道文件来自上传、历史输入还是 agent workspace 输出。
+- 选择文件后正文插入人类可读 token，例如 `#report.md`。
+- 发送时携带结构化 references；后端解析 references，自动补齐本轮 `input_files`。
+- runtime 仍以 staged `input_files.path` 为准，不让模型依赖 UI token 或 OSS key。
+- 历史消息可以把已验证的 `#file` 渲染为 file chip。
+- 编辑、重跑和 queued query 更新不能让正文 token 与实际 runtime inputs 脱节。
+
+### 非目标
+
+- 不把普通聊天强行改造成频道 artifact runtime。
+- 不让 executor 直接读取任意 OSS key 或浏览器预签名 URL。
+- 不在 prompt 中塞文件内容全文。
+- 不支持跨会话文件引用。
+- 不把 local mount 的任意文件默认纳入第一版引用范围；local mount 文件需要单独权限和读取策略。
+- 不引入完整富文本编辑器；第一版继续使用 textarea + draft reference 状态。
+
+### 关键洞察
+
+#### 1. UI 对象应统一，runtime 输入仍可归一到 `input_files`
+
+用户看到的是统一文件对象，后端执行时需要的是 staged input。两者不矛盾：reference 可以保留原始来源类型，后端在 enqueue 前把被引用文件统一提升为本轮 `input_files`。
+
+#### 2. workspace 文件已经有事实源
+
+session/run workspace export 已经记录 `workspace_manifest_key` 和 `workspace_files_prefix`，并通过 `/sessions/{session_id}/workspace/files`、`/runs/{run_id}/workspace/files` 暴露 `FileNode`。manifest 中的 file entry 包含 workspace path、OSS object key、size、mime type，可用于生成 synthetic `InputFile`。
+
+#### 3. 不能让前端预签名 URL 成为执行事实源
+
+前端 artifacts panel 能拿到 preview URL，但 runtime 不应该依赖这个 URL。后端必须从 session ownership 和 workspace manifest 校验引用，再使用 object key 构造 `InputFile.source`。
+
+#### 4. 默认引用 session latest workspace
+
+继续聊天时默认引用当前会话最新 workspace export，而不是当前 UI 选中的历史 run 快照。run-scoped workspace 文件可以用于浏览，但发送下一轮时应以 session latest 为默认事实源，避免旧 run 文件覆盖当前 workspace 语义。
+
+---
+
+## 统一契约
+
+### Frontend `ChatFileReference`
+
+```ts
+type ChatFileReference =
+  | {
+      id: string;
+      kind: "input_file";
+      source: string;
+      insertedText: string;
+      displayName: string;
+      range?: { start: number; end: number };
+      metadata?: {
+        inputFileId?: string | null;
+        size?: number | null;
+        contentType?: string | null;
+        path?: string | null;
+      };
+    }
+  | {
+      id: string;
+      kind: "workspace_file";
+      sessionId: string;
+      path: string;
+      insertedText: string;
+      displayName: string;
+      range?: { start: number; end: number };
+      metadata?: {
+        size?: number | null;
+        contentType?: string | null;
+        sourceKind?: string | null;
+      };
+    };
+```
+
+第一版保留 discriminated union，避免把 workspace path 和 upload source 混成一个字段。UI 层可以统一展示为文件候选，后端按 `kind` 做权限校验和 runtime input 生成。
+
+### Backend `FileReference`
+
+后端 schema 与前端字段同构，接收 `TaskConfig.file_references`。为兼容 `ae3623a3` 已落地的前端基线，短期可以继续接受 `input_file_references` 作为 alias，但内部服务应统一转成 `file_references`。
+
+### Runtime 转换
+
+后端创建 run snapshot 前执行：
+
+1. 合并 project inputs、当前上传 attachments、历史/引用需要的 synthetic inputs。
+2. 对 `input_file` reference，要求 `source` 能在合并后的 input files 中找到。
+3. 对 `workspace_file` reference，要求 session 属于当前用户、workspace export ready、manifest 中存在该 path。
+4. 从 manifest entry 构造 `InputFile`：
+   - `type = "file"`
+   - `name = basename(path)`
+   - `source = manifest entry key`
+   - `size = manifest entry size`
+   - `content_type = manifest entry mimeType`
+   - `path = /inputs/<normalized workspace path without leading slash>`
+5. 保存 `input_files` 和 `file_references` 到 run config snapshot。
+
+---
+
+## Phase 1: 固定统一会话文件引用契约
+
+### 任务
+
+- 将前端 `ChatInputFileReference` 扩展或重命名为统一 `ChatFileReference`。
+- 后端新增 `FileReference` schema，支持 `input_file` 与 `workspace_file`。
+- `TaskConfig` 增加 `file_references`，兼容旧的 `input_file_references` 入参。
+- 更新 executor manager / executor schema 只透传已解析后的 references。
+
+### 验收
+
+- `input_file` 与 `workspace_file` 不共用含义模糊的 `source` 字段。
+- 旧前端基线可继续发送当前上传引用。
+- 新字段命名反映“会话文件”，不再暗示只支持本轮 input files。
+
+## Phase 2: 前端候选源扩展为当前会话文件索引
+
+### 任务
+
+- 复用已落地的 `#` trigger、候选菜单和键盘选择。
+- 新增 session file candidate 构建逻辑：
+  - 当前 draft attachments。
+  - 历史消息 attachments。
+  - session latest workspace files。
+- 去重策略：同一 `kind + source/path` 只显示一次；同名文件用路径或来源说明区分。
+- 首页 task composer 没有 session 上下文时，仅显示当前 draft attachments。
+
+### 验收
+
+- 在已有会话继续输入 `#` 时可以看到 agent 生成的 workspace 文件。
+- 新建任务首页不会请求不存在的 session workspace。
+- 删除正文 token 或删除 draft attachment 会过滤对应 stale reference。
+
+## Phase 3: 后端解析引用并提升为本轮 runtime inputs
+
+### 任务
+
+- 新增 file reference resolver service。
+- 从 session workspace manifest 解析 workspace file reference。
+- 将 workspace file synthetic input 合并进 run snapshot `input_files`。
+- 确保 executor manager 仍只通过 `input_files` staging。
+- 让 queued item update 同步过滤/解析 references。
+
+### 验收
+
+- 引用不存在的 workspace path 返回 400。
+- 引用其他用户/其他 session 文件返回 403 或 400。
+- workspace reference 出现在本轮 `input_files` 后能 staging 到 `/workspace/inputs/...`。
+- 不依赖 preview URL。
+
+## Phase 4: 历史消息渲染、编辑、重跑和队列项兼容
+
+### 任务
+
+- user message metadata 保存 `file_references`。
+- parser 解析 snake_case / camelCase references。
+- chip 渲染统一展示 upload/workspace 文件。
+- edit/regenerate 复用原 run references，并按新 prompt 过滤删除的 token。
+
+### 验收
+
+- 历史 user message 中 `#file` 渲染为 chip。
+- 编辑删除 `#file` 后 references 不再进入新 run。
+- regenerate 原消息会保留当时引用过的文件。
+
+## Phase 5: 验证、回归和文档回写
+
+### 验证命令
+
+- `cd frontend && node --test --experimental-strip-types --experimental-specifier-resolution=node features/chat/lib/input-file-reference.test.ts features/chat/services/message-parser.test.ts`
+- `cd frontend && pnpm lint`
+- `cd frontend && pnpm build`
+- `cd backend && uv run python -m unittest tests.test_task_service tests.test_session_queue_service`
+- `cd executor && uv run python -m unittest tests.test_engine_input_hint`
+- `uv run ruff check <changed-python-files>`
+- `python3 -m py_compile <changed-python-files>`
+
+### 手动验收
+
+- 在已有会话中让 agent 创建文件。
+- 继续输入下一条消息，输入 `#`，能看到刚创建的文件。
+- 选择该文件发送后，agent 能在 `/workspace/inputs/...` 看到并读取该文件。
+- 历史消息中该引用显示为 file chip。

--- a/specs/constitution/2026-06-11-executor-manager-workspace-authorization.md
+++ b/specs/constitution/2026-06-11-executor-manager-workspace-authorization.md
@@ -1,0 +1,171 @@
+# Executor Manager API 鉴权边界决策
+
+## 元数据
+
+| 字段 | 值 |
+| --- | --- |
+| **决策日期** | 2026-06-11 |
+| **关联 spec** | `specs/active/33-executor-manager-workspace-authorization-hardening-plan.md` |
+| **关联 issue** | `poco-ai/poco-claw#133` |
+
+## 决策摘要
+
+`poco-ai/poco-claw#133` 直接暴露的问题是 Executor Manager 的 `/api/v1/workspace/*` 接口没有鉴权，调用方只要能访问 EM，就可以把 URL 里的 `user_id` 换成别人并读取、列举、归档或删除对应执行 workspace。
+
+进一步检查后，EM 还有一些非 health 接口也没有 HTTP 层 token。最终决定是：**EM 除健康检查外，所有接口都必须明确属于某一类受信调用方，并使用对应 token**。
+
+第一类是 Backend 或内部服务调用 EM 的控制面接口，统一使用 `X-Internal-Token`。第二类是 executor container 回传进度、截图、memory、channel tool 调用等执行器回传/工具代理接口，统一使用 `Authorization: Bearer <callback_token>`。Backend 面向用户的 `/sessions/{session_id}/workspace/*` 和 `/runs/{run_id}/workspace/*` 接口保持现状，不迁移到 EM，也不改变前端 Artifacts 体验。
+
+## 背景
+
+当前 Poco 的服务边界大致是：
+
+- Frontend 调 Backend 用户态 API；
+- Backend 用用户登录态做业务鉴权，并用 `X-Internal-Token` 调内部接口；
+- Executor Manager 负责调度、容器管理、workspace 管理，并把 executor container 的回调转发给 Backend；
+- Executor container 通过 EM 提交 callback、截图、memory 和 channel runtime tool 请求。
+
+Backend 用户态 workspace API 本身已有 owner check。例如 `/api/v1/sessions/{session_id}/workspace/files` 会先解析当前用户，再校验 `AgentSession.user_id`。所以 issue #133 的核心不是 Backend 用户接口，而是 EM 的 live workspace 接口。
+
+EM 当前存在三种接口状态：
+
+- 已经走 `X-Internal-Token`：例如 `/api/v1/internal/runs/notify`。
+- 已经走 callback token：例如 `/api/v1/skills/submit`。
+- 还没有 HTTP token：例如 `/api/v1/workspace/*`、`/api/v1/tasks`、`/api/v1/executor/*`、`/api/v1/schedules`、`/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories`、`/api/v1/agent-channel-*`、`/api/v1/user-input-requests`。
+
+由于 `docker-compose.yml` 默认把 EM `8001` 映射到宿主机端口，不能把“它理论上只给内部服务用”当成代码层面的安全保证。即使部署上应避免公网暴露，代码也应该做到 fail closed。
+
+## 用户叙事
+
+**Alice 是普通用户，在页面里查看 agent 产物。**
+
+1. Alice 打开 Artifacts 面板。
+2. Frontend 继续调用 Backend `/api/v1/sessions/{session_id}/workspace/files`。
+3. Backend 校验 Alice 是否拥有该 session，再返回文件树和预览 URL。
+4. Alice 的体验不变，不需要知道 EM 地址，也不能直接访问 EM workspace 文件。
+
+**Bob 是外部调用者，能打到 EM 端口。**
+
+1. Bob 请求 `/api/v1/workspace/file/alice/{session_id}?path=secrets.txt`。
+2. 因为请求没有 `X-Internal-Token`，EM 返回 `403`。
+3. Bob 即使知道 `user_id/session_id/path`，也不能绕过 Backend 用户态授权。
+
+**Backend 需要创建任务或删除容器。**
+
+1. Backend 调 `/api/v1/tasks` 或 `/api/v1/executor/delete`。
+2. 请求必须带 `X-Internal-Token`。
+3. EM 只接受与自身配置一致的内部 token。
+
+**Executor container 需要回传执行信息。**
+
+1. EM dispatch 任务时把 `callback_token` 传给 executor。
+2. Executor 调 `/api/v1/callback`、`/api/v1/computer/screenshots`、`/api/v1/memories` 或 `/api/v1/agent-channel-*` 时带 `Authorization: Bearer <callback_token>`。
+3. EM 只接受合法 callback token，再把请求转发给 Backend internal API。
+
+## 最终决策
+
+这次决策的核心是：**EM 不是用户态入口。EM 的非 health API 必须按调用方类型显式鉴权。**
+
+- **产品决策**：用户态文件浏览、archive 下载、share link、share to channel 的入口继续在 Backend；正常用户体验不变。
+- **技术决策**：内部控制面接口使用 `X-Internal-Token`，包括 `/workspace/*`、`/tasks`、`/executor/*`、`/schedules`。
+- **技术决策**：执行器回传/工具代理接口使用 `Authorization: Bearer <callback_token>`，包括 `/callback`、`/computer/screenshots`、`/memories`、`/agent-channel-*`、`/user-input-requests`。
+- **技术决策**：`/internal/runs/notify` 保持 `X-Internal-Token`；`/skills/submit` 保持 callback token。
+- **技术决策**：v1 不引入 session-scoped workspace capability。这个可以作为后续更细粒度加固，但不是当前 issue 的第一优先级。
+- **技术决策**：`user_id`、`session_id`、`path` 都只能作为业务参数，不能替代 token 鉴权。
+
+## 设计约束与不变量
+
+- EM 只保留 `/api/v1/health`、`/api/v1/` 这类健康/状态接口无 token；其他接口必须有 token。
+- Backend 调 EM 控制面时必须带 `X-Internal-Token`。
+- Executor 调 EM 回传/工具代理接口时必须带 callback token。
+- 不要把所有 EM 接口一刀切成 `X-Internal-Token`，否则 executor container 现有调用链会断。
+- 不要把所有 EM 接口一刀切成 callback token，控制面接口仍应只允许 Backend/internal service。
+- Frontend 不直接访问 EM。
+- Backend 用户态接口继续使用登录态和 session/run owner check。
+- `/api/v1/workspace/*` 即使加了 internal token，也不能把 URL 中的 `user_id` 当作用户身份；后续可继续收敛 legacy `{user_id}/{session_id}` 路径。
+- `INTERNAL_API_TOKEN` 和 `CALLBACK_TOKEN` 在生产环境不能使用默认值。
+
+## 技术设计与结构边界
+
+### EM API 分类
+
+| 接口 | 调用方 | 鉴权方式 | 说明 |
+| --- | --- | --- | --- |
+| `/api/v1/health`、`/api/v1/` | health check / service discovery | 无 token | 只返回服务状态 |
+| `/api/v1/internal/runs/notify` | Backend | `X-Internal-Token` | 已符合目标状态 |
+| `/api/v1/workspace/*` | Backend / internal admin | `X-Internal-Token` | issue #133 核心修复面 |
+| `/api/v1/tasks` | Backend | `X-Internal-Token` | 创建/查询任务，属于控制面 |
+| `/api/v1/executor/*` | Backend / internal admin | `X-Internal-Token` | cancel/delete/load，属于控制面 |
+| `/api/v1/schedules` | Backend | `X-Internal-Token` | 当前由 Backend proxy 给前端展示 |
+| `/api/v1/callback` | Executor container | callback token | agent 进度/状态回传 |
+| `/api/v1/computer/screenshots` | Executor container | callback token | 浏览器截图上传 |
+| `/api/v1/memories` | Executor container | callback token | memory tool proxy |
+| `/api/v1/agent-channel-*` | Executor container | callback token | channel runtime/artifact/task tool proxy |
+| `/api/v1/user-input-requests` | Executor container | callback token | user-input tool proxy |
+| `/api/v1/skills/submit` | Executor helper | callback token | 已符合 v1 目标状态 |
+
+### 内部控制面
+
+控制面接口统一依赖 `require_internal_token`。同时需要补齐调用方：
+
+- `backend/app/services/executor_manager_client.py` 调 `/api/v1/executor/delete` 时带 `X-Internal-Token`。
+- `backend/app/api/v1/schedules.py` proxy `/api/v1/schedules` 时带 `X-Internal-Token`。
+- 创建任务的 Backend 调用路径如果仍走 `/api/v1/tasks`，也必须带 `X-Internal-Token`。
+
+### Executor 回传和工具代理
+
+回传/工具代理接口统一依赖 `require_callback_token`。同时需要补齐 executor 侧 client：
+
+- `executor/app/core/callback.py` 的 `CallbackClient` 带 `Authorization: Bearer <callback_token>`。
+- `executor/app/core/computer.py` 的 `ComputerClient` 带 callback token。
+- `executor/app/core/memory.py` 的 `MemoryClient` 带 callback token。
+- `executor/app/core/channel_runtime.py` 的 `ChannelRuntimeClient` 带 callback token。
+- `executor/app/core/user_input.py` 的 `UserInputClient` 带 callback token。
+- `executor/app/api/v1/task.py` 在构造这些 client 时传入 `req.callback_token`。
+
+### Backend 用户态入口
+
+Backend 用户态接口不是本次问题的根源，保持现有职责：
+
+1. 从 cookie/bearer token 解析用户。
+2. 查 session/run。
+3. 校验 owner 或明确的协作权限。
+4. 授权通过后读取 workspace export manifest 或生成 presigned URL。
+
+### 数据流
+
+```mermaid
+flowchart TD
+    Frontend["Frontend"] -->|"auth cookie / bearer"| Backend["Backend user API"]
+    Backend -->|"X-Internal-Token"| EMControl["EM control plane: workspace/tasks/executor/schedules"]
+    EM["Executor Manager"] -->|"callback_token in task request"| Executor["Executor container"]
+    Executor -->|"Authorization: Bearer callback_token"| EMCallback["EM callback/tool proxy APIs"]
+    EMCallback -->|"X-Internal-Token"| BackendInternal["Backend internal APIs"]
+```
+
+## 备选方案简述
+
+- **只给 `/workspace/*` 加 token。**
+  能修 issue #133，但 EM 其他控制面和回传接口仍然裸露，后续还会有类似问题。
+
+- **所有 EM 接口都用 `X-Internal-Token`。**
+  不采用。Executor container 当前拿的是 callback token，回传/工具代理接口应该用 callback token，否则要把 internal token 暴露给 executor。
+
+- **所有 EM 接口都用 callback token。**
+  不采用。`/tasks`、`/executor/delete`、`/workspace/delete` 这类控制面能力不应该交给 executor token。
+
+- **直接做 session-scoped capability。**
+  暂不作为 v1。它更细，但会扩大实现范围；当前先统一两类既有 token，把裸接口关闭。
+
+## 约束与前提
+
+- `CALLBACK_TOKEN` 已经通过 EM dispatch 传给 executor，适合作为 executor -> EM 回传鉴权凭证。
+- `INTERNAL_API_TOKEN` 已经用于 Backend/EM 内部接口，适合作为 Backend -> EM 控制面鉴权凭证。
+- 生产部署仍应避免公网暴露 EM 8001；代码鉴权不是网络隔离的替代品。
+
+## 历史变更
+
+| 日期 | 变更内容 | 原因 |
+| --- | --- | --- |
+| 2026-06-11 | 初次记录 | 针对 `poco-ai/poco-claw#133` 和 EM 裸接口盘点，固定两类 token 的 API 鉴权边界 |
+| 2026-06-11 | 实现完成 | 按两类 token 边界落地 EM 路由鉴权、Backend internal header、Executor callback token header，并保留 Backend 用户态 workspace 入口 |


### PR DESCRIPTION
## 新功能
支持在普通聊天中通过 `#` 引用当前会话文件，包括历史输入文件和 agent 在会话 workspace 中生成的文件。

## 实现思路
前端统一 `#` 引用对象并在消息中以内联 chip 渲染；后端对引用做结构化校验。上传/历史输入继续走 `input_files` staging，workspace 文件则保留 `/workspace/...` 路径语义，避免错误映射到 `/inputs/...`。