### PR TITLE
fix(servers): 优化线程交互与执行记录体验

### DIFF
--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -429,7 +429,9 @@ export function ThreadDrawer({
   );
 
   return (
-    <aside className={focused ? embeddedDrawerClassName : overlayDrawerClassName}>
+    <aside
+      className={focused ? embeddedDrawerClassName : overlayDrawerClassName}
+    >
       <div className={drawerHeaderClassName}>
         <div className="flex min-w-0 items-center gap-3">
           <Button

--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -270,6 +270,10 @@ export function ThreadDrawer({
     () => getComposerDraftAttachments(activeReferences),
     [activeReferences],
   );
+  const hasAgentMention = React.useMemo(
+    () => activeReferences.some((reference) => reference.kind === "agent"),
+    [activeReferences],
+  );
 
   const handleDraftValueChange = React.useCallback(
     (nextDraft: string) => {
@@ -478,14 +482,25 @@ export function ThreadDrawer({
           </div>
         ) : null}
         {suggestedMentionHandle ? (
-          <div className="mb-2 flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
-            <Info className="size-4 shrink-0 text-muted-foreground" />
-            <span>
-              {t("conversationView.threadMentionHint")}{" "}
-              <span className="font-medium text-foreground">
-                @{suggestedMentionHandle}
-              </span>
-            </span>
+          <div
+            className={cn(
+              "grid overflow-hidden transition-[grid-template-rows,opacity] duration-300 ease-out",
+              hasAgentMention
+                ? "grid-rows-[0fr] opacity-0"
+                : "grid-rows-[1fr] opacity-100",
+            )}
+          >
+            <div className="overflow-hidden">
+              <div className="mb-2 flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+                <Info className="size-4 shrink-0 text-muted-foreground" />
+                <span>
+                  {t("conversationView.threadMentionHint")}{" "}
+                  <span className="font-medium text-foreground">
+                    @{suggestedMentionHandle}
+                  </span>
+                </span>
+              </div>
+            </div>
           </div>
         ) : null}
         <div className="relative flex w-full min-w-0 items-end gap-2 rounded-lg border border-border bg-card px-3 py-2">

--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -74,6 +74,10 @@ import { ServerAgentAvatar } from "./server-agent-avatar";
 const overlayDrawerClassName =
   "absolute inset-y-0 right-0 z-30 flex w-full flex-col border-l border-border bg-card md:left-[17rem] md:w-auto lg:left-[18rem] xl:static xl:h-full xl:w-full xl:min-w-0 xl:shrink-0";
 
+// Focused variant: thread replaces the channel content in the main column (wider, no overlay).
+const embeddedDrawerClassName =
+  "flex h-full min-h-0 w-full flex-col overflow-hidden bg-card";
+
 const drawerHeaderClassName =
   "flex w-full max-w-full flex-wrap items-center justify-between gap-3 overflow-hidden border-b border-border px-4 py-4 sm:px-6 sm:py-5";
 
@@ -117,9 +121,12 @@ export function ThreadDrawer({
   onUploadFiles,
   onClose,
   onOpenExecution,
+  onOpenAgentProfile,
   onToggleReaction,
   isSending,
   isUploading,
+  focused,
+  onToggleFocus,
 }: {
   thread: ServerConversationMessage[];
   serverId: string | null;
@@ -139,12 +146,15 @@ export function ThreadDrawer({
   onUploadFiles: (files: File[]) => Promise<InputFile[]>;
   onClose: () => void;
   onOpenExecution?: (sessionId: string) => void;
+  onOpenAgentProfile?: (agentId: string) => void;
   onToggleReaction?: (
     message: ServerConversationMessage,
     emoji: string,
   ) => void;
   isSending: boolean;
   isUploading?: boolean;
+  focused?: boolean;
+  onToggleFocus?: () => void;
 }) {
   const { t } = useT("translation");
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -419,7 +429,7 @@ export function ThreadDrawer({
   );
 
   return (
-    <aside className={overlayDrawerClassName}>
+    <aside className={focused ? embeddedDrawerClassName : overlayDrawerClassName}>
       <div className={drawerHeaderClassName}>
         <div className="flex min-w-0 items-center gap-3">
           <Button
@@ -436,9 +446,24 @@ export function ThreadDrawer({
             {t("conversationView.threadTitle")}
           </p>
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={onClose}>
-          {t("conversationView.close")}
-        </Button>
+        <div className={drawerHeaderActionsClassName}>
+          {onToggleFocus ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onToggleFocus}
+              className="hidden xl:inline-flex"
+            >
+              {focused
+                ? t("conversationView.backToChannel")
+                : t("conversationView.focusThread")}
+            </Button>
+          ) : null}
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            {t("conversationView.close")}
+          </Button>
+        </div>
       </div>
       <div className="flex min-h-0 flex-1">
         <div className="min-h-0 flex-1 overflow-y-auto">
@@ -450,8 +475,8 @@ export function ThreadDrawer({
                 members={members}
                 presets={presets}
                 defaultExpanded={index === thread.length - 1}
-                onOpenThread={() => undefined}
                 onOpenExecution={onOpenExecution}
+                onOpenAgentProfile={onOpenAgentProfile}
                 onToggleSaved={() => undefined}
                 onToggleReaction={(emoji) => onToggleReaction?.(message, emoji)}
               />
@@ -1066,7 +1091,6 @@ export function TaskDrawer({
                     <MessageRow
                       message={toConversationMessage(item)}
                       agents={agents}
-                      onOpenThread={() => undefined}
                       onToggleSaved={() => undefined}
                       compact
                     />

--- a/frontend/features/servers/ui/conversation-drawers.tsx
+++ b/frontend/features/servers/ui/conversation-drawers.tsx
@@ -3,11 +3,14 @@
 import React from "react";
 import {
   ArrowLeft,
+  ArrowUp,
   Bot,
+  Check,
   Files,
   Info,
   Loader2,
   MessageSquare,
+  Paperclip,
   Pause,
   Plus,
   SquareCheckBig,
@@ -19,7 +22,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { FileCard } from "@/components/shared/file-card";
 import { PersistentRuntimeBadge } from "@/components/shared/persistent-runtime-badge";
-import { Textarea } from "@/components/ui/textarea";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { InputFile } from "@/features/chat/types";
 import type { Preset } from "@/features/capabilities/presets/lib/preset-types";
 import { ExecutionContainer } from "@/features/chat";
@@ -111,6 +119,7 @@ export function ThreadDrawer({
   onOpenExecution,
   onToggleReaction,
   isSending,
+  isUploading,
 }: {
   thread: ServerConversationMessage[];
   serverId: string | null;
@@ -135,12 +144,26 @@ export function ThreadDrawer({
     emoji: string,
   ) => void;
   isSending: boolean;
+  isUploading?: boolean;
 }) {
   const { t } = useT("translation");
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const isComposingRef = React.useRef(false);
   const [selectionStart, setSelectionStart] = React.useState(0);
+
+  const syncTextareaHeight = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+  }, []);
+
+  React.useEffect(() => {
+    syncTextareaHeight();
+  }, [draft, syncTextareaHeight]);
 
   const composerTrigger = React.useMemo(
     () => getComposerTrigger(draft),
@@ -432,7 +455,7 @@ export function ThreadDrawer({
           ))}
         </div>
       </div>
-      <div className="border-t border-border px-6 py-5">
+      <div className="border-t border-border px-6 py-4">
         <input
           type="file"
           multiple
@@ -443,19 +466,19 @@ export function ThreadDrawer({
           }}
         />
         {confirmedAttachments.length > 0 ? (
-          <div className="mb-3 flex flex-wrap gap-2">
+          <div className="mb-2 flex min-w-0 flex-wrap gap-2 px-3">
             {confirmedAttachments.map((file, index) => (
               <FileCard
                 key={`${file.source}-${index}`}
                 file={file}
                 onRemove={() => handleRemoveAttachment(index)}
-                className="w-full max-w-56 bg-background"
+                className="w-full max-w-48 bg-background"
               />
             ))}
           </div>
         ) : null}
         {suggestedMentionHandle ? (
-          <div className="mb-3 flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+          <div className="mb-2 flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
             <Info className="size-4 shrink-0 text-muted-foreground" />
             <span>
               {t("conversationView.threadMentionHint")}{" "}
@@ -465,7 +488,7 @@ export function ThreadDrawer({
             </span>
           </div>
         ) : null}
-        <div className="relative">
+        <div className="relative flex w-full min-w-0 items-end gap-2 rounded-lg border border-border bg-card px-3 py-2">
           {composerActive ? (
             <div className="absolute bottom-full left-0 z-20 mb-2 w-full max-w-md rounded-md border border-border bg-popover p-2 shadow-[var(--shadow-lg)]">
               <div className="px-2 pb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
@@ -511,7 +534,52 @@ export function ThreadDrawer({
               </div>
             </div>
           ) : null}
-          <Textarea
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={isSending || isUploading}
+                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={t("conversationView.composerActions")}
+                title={t("conversationView.composerActions")}
+              >
+                {isUploading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              side="top"
+              sideOffset={8}
+              className="w-36"
+            >
+              <DropdownMenuItem
+                disabled={isSending || isUploading}
+                onSelect={() => fileInputRef.current?.click()}
+              >
+                {isUploading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Paperclip className="size-4" />
+                )}
+                <span>{t("hero.uploadFile")}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={isSending}
+                onSelect={() => onAsTaskChange(!asTask)}
+              >
+                <SquareCheckBig
+                  className={cn("size-4", asTask ? "text-primary" : "")}
+                />
+                <span className="flex-1">{t("conversationView.asTask")}</span>
+                {asTask ? <Check className="size-4 text-primary" /> : null}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <textarea
             ref={textareaRef}
             value={draft}
             onChange={(event) => {
@@ -525,6 +593,7 @@ export function ThreadDrawer({
               setSelectionStart(event.currentTarget.selectionStart)
             }
             onKeyDown={handleKeyDown}
+            onInput={() => syncTextareaHeight()}
             onPaste={(event) => void handlePaste(event)}
             onCompositionStart={() => {
               isComposingRef.current = true;
@@ -534,42 +603,34 @@ export function ThreadDrawer({
                 isComposingRef.current = false;
               });
             }}
-            rows={6}
+            rows={1}
             placeholder={t("conversationView.threadPlaceholder")}
-            className="rounded-md border-border bg-background text-sm shadow-none"
-          />
-        </div>
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            onClick={() => fileInputRef.current?.click()}
             disabled={isSending}
-            aria-label={t("hero.uploadFile")}
-            title={t("hero.uploadFile")}
-          >
-            <Plus className="size-4" />
-          </Button>
-          <label className="flex items-center gap-3 text-base text-foreground">
-            <input
-              type="checkbox"
-              checked={asTask}
-              onChange={(event) => onAsTaskChange(event.target.checked)}
-              className="size-5 rounded-none border-foreground"
-            />
-            {t("conversationView.asTask")}
-          </label>
-          <Button
+            className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 scrollbar-hide"
+            style={{
+              minHeight: "2rem",
+              maxHeight: "10rem",
+              lineHeight: "1.5rem",
+            }}
+          />
+          <button
             type="button"
-            size="sm"
             onClick={onSend}
             disabled={
-              isSending || (!draft.trim() && confirmedAttachments.length === 0)
+              isSending ||
+              isUploading ||
+              (!draft.trim() && confirmedAttachments.length === 0)
             }
+            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:opacity-50"
+            aria-label={t("conversationView.send")}
+            title={t("conversationView.send")}
           >
-            {t("conversationView.send")}
-          </Button>
+            {isSending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ArrowUp className="size-4" />
+            )}
+          </button>
         </div>
       </div>
     </aside>

--- a/frontend/features/servers/ui/conversation-message-row.tsx
+++ b/frontend/features/servers/ui/conversation-message-row.tsx
@@ -65,7 +65,7 @@ type MessageRowProps = {
   isSaved?: boolean;
   compact?: boolean;
   defaultExpanded?: boolean;
-  onOpenThread: () => void;
+  onOpenThread?: () => void;
   onOpenExecution?: ((sessionId: string) => void) | undefined;
   onOpenAgentProfile?: ((agentId: string) => void) | undefined;
   onToggleSaved: () => void;
@@ -651,7 +651,7 @@ function getExecutionStatusTone(status: string | null | undefined): string {
     case "canceling":
       return "bg-orange-500";
     case "running":
-      return "bg-amber-500";
+      return "bg-primary";
     default:
       return "bg-muted-foreground";
   }
@@ -673,6 +673,10 @@ function getExecutionStatusLabelKey(status: string | null | undefined): string {
     default:
       return "conversationView.execution.status.queued";
   }
+}
+
+function isExecutionRunning(status: string | null | undefined): boolean {
+  return (status || "").trim().toLowerCase() === "running";
 }
 
 function StandardMessageRow({
@@ -733,10 +737,6 @@ function StandardMessageRow({
           );
         }) ??
         null)
-      : null;
-  const executionSessionId =
-    executionMessage && typeof executionMessage.content.session_id === "string"
-      ? executionMessage.content.session_id
       : null;
   const canCollapseMessage =
     !executionMessage && Boolean(text) && message.messageType !== "task";
@@ -850,20 +850,58 @@ function StandardMessageRow({
       )}
       <div className="relative min-w-0 flex-1 space-y-1.5">
         <div className="flex items-start justify-between gap-3 text-sm">
-          <div className="min-w-0 flex flex-wrap items-center gap-3">
-            <span className="text-sm font-semibold text-foreground">
-              {author}
-            </span>
-            <span className="text-sm text-muted-foreground">
-              {formatRelativeDate(message.createdAt)}{" "}
-              {formatTime(message.createdAt)}
-            </span>
-            {channelLabel ? (
-              <span className="text-sm text-muted-foreground">
-                #{channelLabel}
+          {executionMessage ? (
+            <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+              <span
+                className={cn(
+                  "size-1.5 shrink-0 rounded-full",
+                  getExecutionStatusTone(
+                    executionMessage.content.execution_status,
+                  ),
+                  isExecutionRunning(
+                    executionMessage.content.execution_status,
+                  ) && "animate-pulse",
+                )}
+              />
+              <span className="shrink-0">
+                {t(
+                  getExecutionStatusLabelKey(
+                    executionMessage.content.execution_status,
+                  ),
+                )}
               </span>
-            ) : null}
-          </div>
+              {executionMessage.content.todo_progress &&
+              executionMessage.content.todo_progress.total > 0 ? (
+                <span className="shrink-0">
+                  {t("conversationView.execution.todoProgress", {
+                    completed:
+                      executionMessage.content.todo_progress.completed ?? 0,
+                    total: executionMessage.content.todo_progress.total ?? 0,
+                  })}
+                </span>
+              ) : null}
+              {executionMessage.content.current_step ? (
+                <span className="min-w-0 truncate">
+                  {executionMessage.content.current_step}
+                </span>
+              ) : null}
+            </div>
+          ) : (
+            <div className="min-w-0 flex flex-wrap items-center gap-3">
+              <span className="text-sm font-semibold text-foreground">
+                {author}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {formatRelativeDate(message.createdAt)}{" "}
+                {formatTime(message.createdAt)}
+              </span>
+              {channelLabel ? (
+                <span className="text-sm text-muted-foreground">
+                  #{channelLabel}
+                </span>
+              ) : null}
+            </div>
+          )}
           <div className="absolute right-0 top-0 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100">
             {onToggleReaction ? (
               <div className="relative">
@@ -891,17 +929,19 @@ function StandardMessageRow({
             >
               <Copy className="size-4" />
             </button>
-            <button
-              type="button"
-              onClick={onOpenThread}
-              aria-label={t("conversationView.reply")}
-              className="inline-flex size-8 items-center justify-center gap-1 rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            >
-              <MessageSquare className="size-3.5" />
-              {message.replyCount > 0 ? (
-                <span className="tabular-nums">{message.replyCount}</span>
-              ) : null}
-            </button>
+            {onOpenThread ? (
+              <button
+                type="button"
+                onClick={onOpenThread}
+                aria-label={t("conversationView.reply")}
+                className="inline-flex size-8 items-center justify-center gap-1 rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              >
+                <MessageSquare className="size-3.5" />
+                {message.replyCount > 0 ? (
+                  <span className="tabular-nums">{message.replyCount}</span>
+                ) : null}
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={onToggleSaved}
@@ -919,62 +959,12 @@ function StandardMessageRow({
           </div>
         </div>
         {executionMessage ? (
-          <button
-            type="button"
-            onClick={() => {
-              if (executionSessionId && onOpenExecution) {
-                onOpenExecution(executionSessionId);
-              }
-            }}
-            disabled={!executionSessionId || !onOpenExecution}
-            className={cn(
-              "w-full rounded-md border border-border bg-muted/20 p-4 text-left",
-              executionSessionId && onOpenExecution
-                ? "transition-colors hover:bg-muted/35"
-                : "cursor-default",
-            )}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex min-w-0 flex-wrap items-center gap-3">
-                <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
-                  <span
-                    className={cn(
-                      "size-2 rounded-full",
-                      getExecutionStatusTone(
-                        executionMessage.content.execution_status,
-                      ),
-                    )}
-                  />
-                  {t(
-                    getExecutionStatusLabelKey(
-                      executionMessage.content.execution_status,
-                    ),
-                  )}
-                </span>
-                {executionMessage.content.todo_progress &&
-                executionMessage.content.todo_progress.total > 0 ? (
-                  <span className="text-xs text-muted-foreground">
-                    {t("conversationView.execution.todoProgress", {
-                      completed:
-                        executionMessage.content.todo_progress.completed ?? 0,
-                      total: executionMessage.content.todo_progress.total ?? 0,
-                    })}
-                  </span>
-                ) : null}
-              </div>
-              {executionMessage.content.current_step ? (
-                <p className="min-w-0 max-w-[40%] truncate text-right text-sm font-medium text-foreground">
-                  {executionMessage.content.current_step}
-                </p>
-              ) : null}
-            </div>
-            <div className="mt-2 max-h-[4.5rem] cursor-text select-text overflow-hidden text-sm leading-6 text-muted-foreground">
-              <ServerMessageContent
-                content={text || t("conversationView.execution.emptySummary")}
-                messageContent={message.content}
-              />
-            </div>
-          </button>
+          <div className="line-clamp-2 cursor-text select-text text-sm leading-6 text-muted-foreground">
+            <ServerMessageContent
+              content={text || t("conversationView.execution.emptySummary")}
+              messageContent={message.content}
+            />
+          </div>
         ) : text || attachments.length === 0 ? (
           <div className="group/message min-w-0">
             <div

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -2942,15 +2942,15 @@ export function ServerConversationPageClient({
     );
     const entities = serialized.entities;
     const confirmedAttachments = serialized.attachments;
+    const hasAgentMention = entities.some((entity) => entity.kind === "agent");
     if (!trimmedDraft && confirmedAttachments.length === 0) {
       return;
     }
     setIsSending(true);
     try {
       if (threadAsTask) {
-        const explicitMentions = getExplicitMentionHandles(trimmedDraft);
         const replyText =
-          threadMentionHandle && !explicitMentions.includes(threadMentionHandle)
+          threadMentionHandle && !hasAgentMention
             ? `@${threadMentionHandle} ${trimmedDraft}`
             : trimmedDraft;
         const message = await serversApi.sendMessage(
@@ -2992,9 +2992,8 @@ export function ServerConversationPageClient({
         }));
         toast.success(t("conversationView.toasts.taskCreated"));
       } else {
-        const explicitMentions = getExplicitMentionHandles(trimmedDraft);
         const replyText =
-          threadMentionHandle && !explicitMentions.includes(threadMentionHandle)
+          threadMentionHandle && !hasAgentMention
             ? `@${threadMentionHandle} ${trimmedDraft}`
             : trimmedDraft;
         await serversApi.sendMessage(selectedServerId, drawer.channelId, {

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -2029,6 +2029,10 @@ export function ServerConversationPageClient({
   const [isUploadingDraftFile, setIsUploadingDraftFile] = React.useState(false);
   const [asTask, setAsTask] = React.useState(false);
   const [threadAsTask, setThreadAsTask] = React.useState(false);
+  const [focusedThread, setFocusedThread] = React.useState<{
+    channelId: string;
+    rootMessageId: string;
+  } | null>(null);
   const [savedMessageIds, setSavedMessageIds] = React.useState<Set<string>>(
     new Set(),
   );
@@ -2154,6 +2158,28 @@ export function ServerConversationPageClient({
   const contentAreaRef = React.useRef<HTMLDivElement | null>(null);
   const isResizingDrawerRef = React.useRef(false);
   const hasDesktopDrawer = drawer.type !== "none";
+  // A focused thread lives in the main column independently of the right drawer, so
+  // opening another drawer (agent/execution/colleague) preserves the focus.
+  const activeThreadTarget = React.useMemo<{
+    channelId: string;
+    rootMessageId: string;
+  } | null>(() => {
+    if (focusedThread) {
+      return focusedThread;
+    }
+    if (drawer.type === "thread") {
+      return {
+        channelId: drawer.channelId,
+        rootMessageId: drawer.rootMessageId,
+      };
+    }
+    return null;
+  }, [drawer, focusedThread]);
+
+  // Leaving the current channel/server invalidates a focused thread.
+  React.useEffect(() => {
+    setFocusedThread(null);
+  }, [selectedServerId, activeChannelId]);
   const feedModeActive = mode === "search" || mode === "inbox";
   const tasksModeActive = Boolean(channelId) && mode === "tasks";
   const colleaguesModeActive = mode === "colleagues";
@@ -2565,7 +2591,7 @@ export function ServerConversationPageClient({
   // regardless of which channel is currently active (matches the top-level
   // channel snapshot polling pattern below).
   React.useEffect(() => {
-    if (drawer.type !== "thread" || !selectedServerId) {
+    if (!activeThreadTarget || !selectedServerId) {
       setThreadMessages([]);
       return;
     }
@@ -2581,8 +2607,8 @@ export function ServerConversationPageClient({
       try {
         const nextThread = await serversApi.getThread(
           selectedServerId,
-          drawer.channelId,
-          drawer.rootMessageId,
+          activeThreadTarget.channelId,
+          activeThreadTarget.rootMessageId,
         );
         if (!cancelled) {
           setThreadMessages(nextThread);
@@ -2603,7 +2629,7 @@ export function ServerConversationPageClient({
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [drawer, selectedServerId, t]);
+  }, [activeThreadTarget, selectedServerId, t]);
 
   React.useEffect(() => {
     if (currentMessages.length === 0 || mode === "inbox" || mode === "search") {
@@ -2613,11 +2639,11 @@ export function ServerConversationPageClient({
   }, [currentMessages, markMessagesRead, mode]);
 
   React.useEffect(() => {
-    if (drawer.type !== "thread" || threadMessages.length === 0) {
+    if (!activeThreadTarget || threadMessages.length === 0) {
       return;
     }
     markMessagesRead(threadMessages.map((message) => message.id));
-  }, [drawer, markMessagesRead, threadMessages]);
+  }, [activeThreadTarget, markMessagesRead, threadMessages]);
 
   React.useEffect(() => {
     if (!selectedServerId || !activeChannelId || !selectedChannel) {
@@ -2932,9 +2958,11 @@ export function ServerConversationPageClient({
   };
 
   const handleReply = async () => {
-    if (drawer.type !== "thread" || !selectedServerId) {
+    if (!activeThreadTarget || !selectedServerId) {
       return;
     }
+    const threadChannelId = activeThreadTarget.channelId;
+    const threadRootMessageId = activeThreadTarget.rootMessageId;
     const trimmedDraft = threadDraft.trim();
     const serialized = serializeComposerReferencesForSend(
       trimmedDraft,
@@ -2955,19 +2983,19 @@ export function ServerConversationPageClient({
             : trimmedDraft;
         const message = await serversApi.sendMessage(
           selectedServerId,
-          drawer.channelId,
+          threadChannelId,
           {
             text: replyText,
             attachments: confirmedAttachments,
             entities: entities.length > 0 ? entities : undefined,
-            threadRootMessageId: drawer.rootMessageId,
+            threadRootMessageId: threadRootMessageId,
             asTask: true,
           },
         );
         const title =
           trimmedDraft.split("\n")[0]?.trim().slice(0, 80) ||
           trimmedDraft.slice(0, 80);
-        await channelTasksApi.createTask(selectedServerId, drawer.channelId, {
+        await channelTasksApi.createTask(selectedServerId, threadChannelId, {
           title,
           description:
             trimmedDraft ||
@@ -2980,15 +3008,15 @@ export function ServerConversationPageClient({
         setThreadDraftReferences([]);
         setThreadAsTask(false);
         setTasks(
-          await channelTasksApi.listTasks(selectedServerId, drawer.channelId),
+          await channelTasksApi.listTasks(selectedServerId, threadChannelId),
         );
         const messages = await serversApi.listMessages(
           selectedServerId,
-          drawer.channelId,
+          threadChannelId,
         );
         setMessagesByChannel((current) => ({
           ...current,
-          [drawer.channelId]: messages,
+          [threadChannelId]: messages,
         }));
         toast.success(t("conversationView.toasts.taskCreated"));
       } else {
@@ -2996,25 +3024,25 @@ export function ServerConversationPageClient({
           threadMentionHandle && !hasAgentMention
             ? `@${threadMentionHandle} ${trimmedDraft}`
             : trimmedDraft;
-        await serversApi.sendMessage(selectedServerId, drawer.channelId, {
+        await serversApi.sendMessage(selectedServerId, threadChannelId, {
           text: replyText,
           attachments: confirmedAttachments,
           entities: entities.length > 0 ? entities : undefined,
-          threadRootMessageId: drawer.rootMessageId,
+          threadRootMessageId: threadRootMessageId,
         });
         setThreadDraft("");
         setThreadDraftReferences([]);
         const [messages, thread] = await Promise.all([
-          serversApi.listMessages(selectedServerId, drawer.channelId),
+          serversApi.listMessages(selectedServerId, threadChannelId),
           serversApi.getThread(
             selectedServerId,
-            drawer.channelId,
-            drawer.rootMessageId,
+            threadChannelId,
+            threadRootMessageId,
           ),
         ]);
         setMessagesByChannel((current) => ({
           ...current,
-          [drawer.channelId]: messages,
+          [threadChannelId]: messages,
         }));
         setThreadMessages(thread);
       }
@@ -3781,7 +3809,43 @@ export function ServerConversationPageClient({
                 "xl:flex-none xl:w-[calc(100%_-_var(--server-drawer-width)_-_0.25rem)]",
             )}
           >
-            {feedModeActive ? (
+            {focusedThread ? (
+              <ThreadDrawer
+                thread={threadMessages}
+                serverId={selectedServerId}
+                channelId={focusedThread.channelId}
+                agents={channelAgents}
+                presets={presets}
+                members={channelMembers}
+                currentUserId={profile?.id}
+                draft={threadDraft}
+                draftReferences={threadDraftReferences}
+                suggestedMentionHandle={threadMentionHandle}
+                asTask={threadAsTask}
+                onDraftChange={setThreadDraft}
+                onDraftReferencesChange={setThreadDraftReferences}
+                onAsTaskChange={setThreadAsTask}
+                onSend={() => void handleReply()}
+                onUploadFiles={uploadThreadDraftFiles}
+                focused
+                onToggleFocus={() => setFocusedThread(null)}
+                onClose={() => setFocusedThread(null)}
+                onOpenExecution={(sessionId) =>
+                  setDrawer({ type: "execution", sessionId })
+                }
+                onOpenAgentProfile={(agentId) =>
+                  setDrawer({
+                    type: "colleague",
+                    selection: { kind: "agent", id: agentId },
+                  })
+                }
+                onToggleReaction={(message, emoji) =>
+                  void handleToggleReaction(message, emoji)
+                }
+                isSending={isSending}
+                isUploading={isUploadingDraftFile}
+              />
+            ) : feedModeActive ? (
               <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                 {mode === "search" ? (
                   <SearchPanel
@@ -3966,11 +4030,24 @@ export function ServerConversationPageClient({
                     onOpenExecution={(sessionId) =>
                       setDrawer({ type: "execution", sessionId })
                     }
+                    onOpenAgentProfile={(agentId) =>
+                      setDrawer({
+                        type: "colleague",
+                        selection: { kind: "agent", id: agentId },
+                      })
+                    }
                     onToggleReaction={(message, emoji) =>
                       void handleToggleReaction(message, emoji)
                     }
                     isSending={isSending}
                     isUploading={isUploadingDraftFile}
+                    onToggleFocus={() => {
+                      setFocusedThread({
+                        channelId: drawer.channelId,
+                        rootMessageId: drawer.rootMessageId,
+                      });
+                      setDrawer({ type: "none" });
+                    }}
                   />
                 ) : drawer.type === "execution" ? (
                   <ExecutionDrawer

--- a/frontend/features/servers/ui/server-conversation-page-client.tsx
+++ b/frontend/features/servers/ui/server-conversation-page-client.tsx
@@ -2561,27 +2561,48 @@ export function ServerConversationPageClient({
     router.replace(`/${lng}/servers?mode=search&server=${selectedServerId}`);
   }, [activeChannelId, channels, lng, router, selectedServerId]);
 
+  // Poll the active thread independently so its placeholder/status stays live
+  // regardless of which channel is currently active (matches the top-level
+  // channel snapshot polling pattern below).
   React.useEffect(() => {
-    const loadThread = async () => {
-      if (drawer.type !== "thread" || !selectedServerId) {
-        setThreadMessages([]);
+    if (drawer.type !== "thread" || !selectedServerId) {
+      setThreadMessages([]);
+      return;
+    }
+
+    let cancelled = false;
+    let inFlight = false;
+
+    const refreshThread = async () => {
+      if (cancelled || inFlight) {
         return;
       }
+      inFlight = true;
       try {
-        setThreadMessages(
-          await serversApi.getThread(
-            selectedServerId,
-            drawer.channelId,
-            drawer.rootMessageId,
-          ),
+        const nextThread = await serversApi.getThread(
+          selectedServerId,
+          drawer.channelId,
+          drawer.rootMessageId,
         );
+        if (!cancelled) {
+          setThreadMessages(nextThread);
+        }
       } catch (error) {
-        console.error("[ServersWorkspace] thread load failed", error);
-        toast.error(t("conversationView.toasts.threadFailed"));
+        if (!cancelled) {
+          console.error("[ServersWorkspace] thread refresh failed", error);
+          toast.error(t("conversationView.toasts.threadFailed"));
+        }
+      } finally {
+        inFlight = false;
       }
     };
 
-    void loadThread();
+    void refreshThread();
+    const intervalId = window.setInterval(refreshThread, 4000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
   }, [drawer, selectedServerId, t]);
 
   React.useEffect(() => {
@@ -2621,16 +2642,7 @@ export function ServerConversationPageClient({
             channelTasksApi.listTasks(selectedServerId, activeChannelId),
           );
         }
-        if (drawer.type === "thread" && drawer.channelId === activeChannelId) {
-          requests.push(
-            serversApi.getThread(
-              selectedServerId,
-              drawer.channelId,
-              drawer.rootMessageId,
-            ),
-          );
-        }
-        const [nextMessages, nextArtifacts, nextTasks, nextThread] =
+        const [nextMessages, nextArtifacts, nextTasks] =
           await Promise.all(requests);
 
         if (cancelled) {
@@ -2643,9 +2655,6 @@ export function ServerConversationPageClient({
         setChannelArtifacts(nextArtifacts as FileNode[]);
         if (mode === "tasks" && Array.isArray(nextTasks)) {
           setTasks(nextTasks as ChannelTask[]);
-        }
-        if (drawer.type === "thread" && Array.isArray(nextThread)) {
-          setThreadMessages(nextThread as ServerConversationMessage[]);
         }
       } catch (error) {
         if (!cancelled) {
@@ -2665,7 +2674,7 @@ export function ServerConversationPageClient({
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [activeChannelId, drawer, mode, selectedChannel, selectedServerId]);
+  }, [activeChannelId, mode, selectedChannel, selectedServerId]);
 
   const openMode = (nextMode: WorkspaceMode) => {
     setMode(nextMode);
@@ -3962,6 +3971,7 @@ export function ServerConversationPageClient({
                       void handleToggleReaction(message, emoji)
                     }
                     isSending={isSending}
+                    isUploading={isUploadingDraftFile}
                   />
                 ) : drawer.type === "execution" ? (
                   <ExecutionDrawer

--- a/frontend/lib/i18n/locales/de/translation.json
+++ b/frontend/lib/i18n/locales/de/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "Antworten bleiben im aktuellen Unterhaltungskontext.",
     "threadPlaceholder": "Thread-Nachricht",
     "close": "Schließen",
+    "focusThread": "Fokussieren",
+    "backToChannel": "Zurück zum Kanal",
     "backToContext": "Im Kanal anzeigen",
     "contextTitle": "Kontextbereich",
     "contextDescription": "Wähle einen Thread oder Agent, um diesen Bereich durch tieferen Kontext zu ersetzen.",

--- a/frontend/lib/i18n/locales/en/translation.json
+++ b/frontend/lib/i18n/locales/en/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "Replies stay attached to the current conversation context.",
     "threadPlaceholder": "Message thread",
     "close": "Close",
+    "focusThread": "Focus",
+    "backToChannel": "Back to channel",
     "backToContext": "View in channel",
     "contextTitle": "Context panel",
     "contextDescription": "Select a thread or agent to replace this panel with deeper context.",

--- a/frontend/lib/i18n/locales/fr/translation.json
+++ b/frontend/lib/i18n/locales/fr/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "Les réponses restent attachées au contexte de conversation actuel.",
     "threadPlaceholder": "Message du fil",
     "close": "Fermer",
+    "focusThread": "Focus",
+    "backToChannel": "Retour au canal",
     "backToContext": "Voir dans le canal",
     "contextTitle": "Panneau de contexte",
     "contextDescription": "Sélectionnez un fil ou un agent pour afficher un contexte plus détaillé.",

--- a/frontend/lib/i18n/locales/ja/translation.json
+++ b/frontend/lib/i18n/locales/ja/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "返信は現在の会話コンテキストに紐づきます。",
     "threadPlaceholder": "スレッドにメッセージ",
     "close": "閉じる",
+    "focusThread": "フォーカス",
+    "backToChannel": "チャンネルに戻る",
     "backToContext": "チャンネルで表示",
     "contextTitle": "コンテキストパネル",
     "contextDescription": "スレッドまたは Agent を選択して、より深いコンテキストを表示します。",

--- a/frontend/lib/i18n/locales/ru/translation.json
+++ b/frontend/lib/i18n/locales/ru/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "Ответы остаются привязанными к текущему контексту беседы.",
     "threadPlaceholder": "Сообщение в тред",
     "close": "Закрыть",
+    "focusThread": "Фокус",
+    "backToChannel": "Вернуться к каналу",
     "backToContext": "Показать в канале",
     "contextTitle": "Панель контекста",
     "contextDescription": "Выберите тред или агента, чтобы открыть более подробный контекст.",

--- a/frontend/lib/i18n/locales/zh/translation.json
+++ b/frontend/lib/i18n/locales/zh/translation.json
@@ -282,6 +282,8 @@
     "threadDescription": "回复会保留在当前 conversation 语境里。",
     "threadPlaceholder": "回复会话串",
     "close": "关闭",
+    "focusThread": "聚焦",
+    "backToChannel": "返回频道",
     "backToContext": "查看频道上下文",
     "contextTitle": "上下文面板",
     "contextDescription": "选择一个 thread 或 agent，让右侧面板切换到更深的上下文。",


### PR DESCRIPTION
### Summary
- 本次变更集中在服务端会话页的线程交互与执行行展示，包含功能修复、交互优化与文案补齐。

### 功能说明

#### 1) 支持主视图聚焦线程会话
- 在主区直接进入线程聚焦模式（`ThreadDrawer`），并增加返回频道。
- 聚焦状态与右侧抽屉解耦，切频道/离开 server 后自动回退与清理。
- 实现要点：通过独立的聚焦线程上下文管理路由，所有回复与任务发送基于当前聚焦目标执行，避免误发到错误会话。

#### 2) 改进线程 composer 与线程轮询
- 优化 composer 为紧凑布局（自动增高输入框、图标化发送、上传态禁用冲突动作），上传中自动阻断不一致操作。
- 实现要点：将线程加载/刷新提取到独立轮询 effect，避免与通用 server 刷新耦合，减少重复请求并保持线程状态更稳定。

#### 3) 修复线程提及前缀重复
- 当草稿已带明确 agent 实体时，不再重复显示/拼接线程提及时缀，减少视觉噪音并统一发送语义。
- 实现要点：发送前先读取实体元数据判断是否已包含有效实体，普通回复和任务回复共享同一判断逻辑。

#### 4) 简化执行行动作与状态展示
- 执行行不再使用易误触发的可点击摘要卡片，改为行内状态线展示；运行态使用更清晰的状态提示。
- 实现要点：状态/进度/当前步骤上移到标题区域，正文降为非交互摘要，保留“保存/复制”等核心动作，并使“打开线程”按钮按需渲染。
