### PR TITLE
fix(frontend): resolve auth redirect loop in cookieless auth modes

### DIFF
--- a/frontend/features/auth/lib/server-session.ts
+++ b/frontend/features/auth/lib/server-session.ts
@@ -14,9 +14,12 @@ export type ServerAuthState =
 
 export const getServerAuthState = cache(async (): Promise<ServerAuthState> => {
   const cookieStore = await cookies();
-  if (!cookieStore.get(AUTH_SESSION_COOKIE_NAME)?.value) {
-    return { status: "anonymous" };
-  }
+  // The backend can authenticate cookieless requests in single-user and
+  // disabled auth modes, so always probe /auth/me and only use cookie
+  // presence to distinguish "anonymous" from "stale" on 401.
+  const hasSessionCookie = Boolean(
+    cookieStore.get(AUTH_SESSION_COOKIE_NAME)?.value,
+  );
 
   try {
     await apiClient.get<unknown>(API_ENDPOINTS.authMe, {
@@ -25,7 +28,7 @@ export const getServerAuthState = cache(async (): Promise<ServerAuthState> => {
     return { status: "authenticated" };
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
-      return { status: "stale" };
+      return { status: hasSessionCookie ? "stale" : "anonymous" };
     }
     throw error;
   }


### PR DESCRIPTION
## Background

When the backend runs in a cookieless auth mode (`AUTH_MODE=single_user`,
`disabled`, or `oauth_optional` with no providers configured), the web UI gets
stuck in an infinite redirect loop between `/{lng}/home` and `/{lng}/login`:

1. The login page's runtime guard fetches `/api/v1/auth/config`, sees
   `single_user_effective: true`, and redirects to `/{lng}/home`.
2. The `(shell)` layout calls `getServerAuthState()`, which short-circuits to
   `anonymous` whenever the `poco_session` cookie is absent — without ever
   consulting the backend — and redirects back to `/{lng}/login`.
3. The backend deliberately never issues a session cookie in these modes
   (`AuthService.start_login` only redirects; `get_current_user_id` in
   `backend/app/core/deps.py` resolves the single user without any cookie),
   so the cookie can never exist and the loop never terminates.

The backend already authenticates cookieless requests correctly by design; the
frontend's server-side gate was simply not aligned with it (the client-side
login-page guard already handles `single_user_effective` properly).

## Changes

`frontend/features/auth/lib/server-session.ts` only:

- `getServerAuthState()` now always probes `/api/v1/auth/me` and treats a 200
  as `authenticated`, instead of short-circuiting to `anonymous` on a missing
  session cookie.
- Cookie presence is only used to distinguish `anonymous` (no cookie, 401)
  from `stale` (cookie present, 401), preserving existing semantics for OAuth
  deployments.

## Behavior matrix

| Scenario | Before | After |
| --- | --- | --- |
| `single_user` / `disabled`, no cookie | `anonymous` (redirect loop) | `authenticated` (backend resolves the single user) |
| OAuth mode, no cookie | `anonymous` | `anonymous` (unchanged; `/auth/me` returns 401) |
| Valid session cookie | `authenticated` | `authenticated` (unchanged) |
| Invalid/expired cookie | `stale` | `stale` (unchanged) |

## Affected areas

- Frontend only. All four `getServerAuthState()` call sites benefit:
  `app/[lng]/page.tsx`, `app/[lng]/login/page.tsx`,
  `app/[lng]/(shell)/layout.tsx`, `app/[lng]/share/[token]/page.tsx`.
- No backend / executor / executor_manager changes. No database changes.
- No breaking changes for OAuth deployments.

## Alternatives considered

Minting a session cookie from the backend in single-user mode
(`AuthService.start_login`) was rejected: the backend intentionally supports
cookieless authentication (`get_current_user_id` falls back to
`ensure_single_user`), and writing unused session rows would add state with no
purpose.

## Verification

- Reproduced on a fresh Docker Compose deployment with
  `AUTH_MODE=single_user`: `/api/v1/auth/config` returns
  `single_user_effective: true`, while the browser ping-pongs between
  `/zh/home` and `/zh/login` with no console errors.
- End-to-end with this patch: ran the modified frontend via
  `BACKEND_URL=http://localhost:8000 pnpm dev --port 3001` against the
  existing Docker Compose stack — `/zh/home` renders the main UI directly
  with no loop, `/zh/login` immediately redirects to home, and session data
  loads correctly over cookieless API calls.
- OAuth regression: temporarily switched back to
  `AUTH_MODE=oauth_required` (no providers configured) — the app now rests
  on the login page statically instead of looping, confirming unchanged
  behavior for OAuth deployments.
- `pnpm lint` — pass
- `pnpm build` — pass
- `pre-commit run --all-files` — pass (no formatting changes to the
  modified file)